### PR TITLE
Add persistability for MCMC warmup and post-warmup state

### DIFF
--- a/CAFAna/Core/Utilities.cxx
+++ b/CAFAna/Core/Utilities.cxx
@@ -166,6 +166,19 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+  TMatrixD TMatrixDFromEigenMatrixXd(const Eigen::MatrixXd& mat)
+  {
+    TMatrixD ret(mat.rows(), mat.cols());
+    // TMatrixD doesn't appear to have a GetArray()
+    for(int i = 0; i < mat.rows(); ++i){
+      for(int j = 0; j < mat.cols(); ++j){
+        ret(i, j) = mat.coeffRef(i, j);
+      }
+    }
+    return ret;
+  }
+
+  //----------------------------------------------------------------------
   double Chi2CovMx(const Eigen::ArrayXd& e, const Eigen::ArrayXd& o, const Eigen::MatrixXd& covmxinv)
   {
     assert(e.size() == covmxinv.rows()+2);

--- a/CAFAna/Core/Utilities.h
+++ b/CAFAna/Core/Utilities.h
@@ -177,6 +177,8 @@ namespace ana
 
   Eigen::MatrixXd EigenMatrixXdFromTMatrixD(const TMatrixD* mat);
 
+  TMatrixD TMatrixDFromEigenMatrixXd(const Eigen::MatrixXd& mat);
+
   /**  \brief Chi-squared calculation using a covariance matrix.
 
        \param exp   Expected bin counts

--- a/CAFAna/Fit/MCMCSamples.cxx
+++ b/CAFAna/Fit/MCMCSamples.cxx
@@ -262,8 +262,8 @@ namespace ana
 
     auto hyperParamsDir = dynamic_cast<TDirectory*>(dir->Get("hyperparams"));
     auto stepSize = hyperParamsDir->Get<TParameter<double>>("stepsize");
-    auto invMetric = hyperParamsDir->Get<TMatrixD>("inv_metric");
-    Hyperparameters hyperparams{stepSize->GetVal(), *invMetric};
+    auto invMetric = std::unique_ptr<TMatrixD>(hyperParamsDir->Get<TMatrixD>("inv_metric"));
+    Hyperparameters hyperparams{stepSize->GetVal(), std::move(invMetric)};
 
     delete dir;
 
@@ -617,13 +617,13 @@ namespace ana
     fSamples->LoadBaskets();
     fSamples->SetDirectory(nullptr);
 
-    TDirectory hyperdir("hyperparams", "Hyperparameters");
-    hyperdir.cd();
+    auto hyperdir = dir->mkdir("hyperparams");
+    hyperdir->cd();
     TParameter<double> stepSize("stepsize", fHyperparams.stepSize);
     stepSize.Write();
-    fHyperparams.invMetric.Write("inv_metric");
+    fHyperparams.invMetric->Write("inv_metric");
     dir->cd();
-    hyperdir.Write();
+    hyperdir->Write();
 
     dir->Write();
     delete dir;

--- a/CAFAna/Fit/MCMCSamples.cxx
+++ b/CAFAna/Fit/MCMCSamples.cxx
@@ -621,7 +621,8 @@ namespace ana
     hyperdir->cd();
     TParameter<double> stepSize("stepsize", fHyperparams.stepSize);
     stepSize.Write();
-    fHyperparams.invMetric->Write("inv_metric");
+    if (fHyperparams.invMetric)
+      fHyperparams.invMetric->Write("inv_metric");
     dir->cd();
     hyperdir->Write();
 

--- a/CAFAna/Fit/MCMCSamples.h
+++ b/CAFAna/Fit/MCMCSamples.h
@@ -2,6 +2,7 @@
 
 #include <vector>
 
+#include "TMatrixD.h"
 #include "TTree.h"
 
 #include "CAFAna/Core/IFitVar.h"
@@ -28,6 +29,17 @@ namespace ana
       /// Name of branch in internal TTree corresponding to the log-likelihood.
       /// Used in several places, so centralized here.
       static const std::string LOGLIKELIHOOD_BRANCH_NAME;
+
+      struct Hyperparameters
+      {
+        double stepSize;
+        TMatrixD invMetric;   // use TMatrix rather than Eigen for peristability
+
+        Hyperparameters(double stepsize = std::numeric_limits<double>::signaling_NaN(),
+                        TMatrixD invmetric = TMatrixD())
+          : stepSize(stepsize), invMetric(invmetric)
+        {}
+      };
 
       /// Build the MCMCSamples object.
       ///
@@ -58,6 +70,8 @@ namespace ana
 
       /// Discard any samples
       void Clear() { fSamples->Clear(); }
+
+      const Hyperparameters & Hyperparams() const   { return fHyperparams; }
 
 
       /// Marginalize over all other variables to obtain a 1D profile in \a var
@@ -139,6 +153,16 @@ namespace ana
                         std::map<const ana::IFitVar *, double> &varVals,
                         const std::vector<const ana::ISyst *> &systs, std::map<const ana::ISyst *, double> &systVals) const;
 
+      void SetHyperparams(double stepSize, TMatrixD invMassMatrix)
+      {
+        fHyperparams = {stepSize, invMassMatrix};
+      }
+
+      void SetHyperparams(Hyperparameters h)
+      {
+        fHyperparams = h;
+      };
+
       void SetNames(const std::vector<std::string>& names);
 
       /// Get a TTree with the MCMC samples in it
@@ -158,11 +182,9 @@ namespace ana
 
     private:
       /// Internal-use constructor needed for LoadFrom()
-      MCMCSamples(std::size_t offset,
-                  const std::vector<std::string>& diagBranchNames,
-                  const std::vector<const IFitVar *> &vars,
-                  const std::vector<const ana::ISyst *> &systs,
-                  std::unique_ptr<TTree> &tree);
+      MCMCSamples(std::size_t offset, const std::vector<std::string> &diagBranchNames,
+                  const std::vector<const IFitVar *> &vars, const std::vector<const ana::ISyst *> &systs,
+                  std::unique_ptr<TTree> &tree, const Hyperparameters &hyperParams);
 
       /// Where in fDiagnosticVals is the given diagnostic?
       std::size_t DiagOffset(const std::string& diagName) const;
@@ -199,6 +221,8 @@ namespace ana
       double fEntryLL;  // for use reading the TTree
       std::vector<double> fEntryVals;  // ditto
       std::vector<double> fDiagnosticVals;
+
+      mutable Hyperparameters fHyperparams;
   };
 
 }

--- a/CAFAna/Fit/MCMCSamples.h
+++ b/CAFAna/Fit/MCMCSamples.h
@@ -220,7 +220,7 @@ namespace ana
       /// Where in fEntryVals is the given syst?
       std::size_t VarOffset(const ana::ISyst * syst) const;
 
-      std::size_t fOffset;
+      std::size_t fOffset;   //< number of branches read out before the fitted parameters start
       std::vector<std::string> fDiagBranches;
       std::vector<const ana::IFitVar *> fVars;
       std::vector<const ana::ISyst *> fSysts;

--- a/CAFAna/Fit/StanConfig.h
+++ b/CAFAna/Fit/StanConfig.h
@@ -21,7 +21,7 @@ namespace ana
                int _num_warmup = 1000,
                int _num_samples = 1000,
                int _num_thin = 1,
-               bool _save_warmup = false,
+               bool _save_warmup = true,  // not Stan default, but we save warmup separately from regular samples, so no chance of getting confused
                int _refresh = 100,
                double _stepsize = 1,
                double _stepsize_jitter = 0,

--- a/CAFAna/Fit/StanFitter.cxx
+++ b/CAFAna/Fit/StanFitter.cxx
@@ -529,7 +529,11 @@ namespace ana
 
     sampler.disengage_adaptation();
     writer.write_adapt_finish(sampler);
-    sampler.write_sampler_state(fValueWriter);
+
+    // -------------------------------
+    // this is the new bit we added in between the bits copied from Stan
+    fValueWriter.SaveSamplerState(sampler);
+    // -------------------------------
 
     start = clock();
     stan::services::util::generate_transitions(sampler,
@@ -547,8 +551,7 @@ namespace ana
                                                interrupt,
                                                logger);
     end = clock();
-    double sample_delta_t
-    = static_cast<double>(end - start) / CLOCKS_PER_SEC;
+    double sample_delta_t = static_cast<double>(end - start) / CLOCKS_PER_SEC;
 
     writer.write_timing(warm_delta_t, sample_delta_t);
 

--- a/CAFAna/Fit/StanFitter.cxx
+++ b/CAFAna/Fit/StanFitter.cxx
@@ -131,6 +131,15 @@ namespace ana
       *fOscCalcCache = *seed;
     }
 
+
+    // check that state of warmup is what we expected
+    if (fStanConfig.num_warmup > 0 && fMCMCWarmup.NumSamples() > 0)
+    {
+      std::cerr << "You supplied a previous collection of MCMC samples for warmup and also requested num_warmup > 0 in your StanConfig." << std::endl;
+      std::cerr << "Which do you want?" << std::endl;
+      abort();
+    }
+
     // const-casts here because we need to initialize the writer interface, which requires a non-const pointer,
     // but this method is const.  prefer not to make the members mutable for this one instance
     fValueWriter = std::make_unique<MemoryTupleWriter>(fStanConfig.num_samples > 0 ? const_cast<MCMCSamples*>(&fMCMCSamples) : nullptr,

--- a/CAFAna/Fit/StanFitter.cxx
+++ b/CAFAna/Fit/StanFitter.cxx
@@ -118,9 +118,11 @@ namespace ana
 
   //----------------------------------------------------------------------
   std::unique_ptr<IFitter::IFitSummary>
-  StanFitter::Fit(osc::IOscCalculatorAdjustable *seed, SystShifts &bestSysts,
+  StanFitter::Fit(osc::IOscCalculatorAdjustable *seed,
+                  SystShifts &bestSysts,
                   const SeedList& seedPts,
-                  const std::vector<SystShifts> &systSeedPts, Verbosity verb) const
+                  const std::vector<SystShifts> &systSeedPts,
+                  Verbosity verb) const
   {
     if (seed)
     {

--- a/CAFAna/Fit/StanFitter.h
+++ b/CAFAna/Fit/StanFitter.h
@@ -11,6 +11,7 @@
 #include "CAFAna/Fit/MCMCSamples.h"
 #include "CAFAna/Fit/StanConfig.h"
 #include "CAFAna/Core/StanTypedefs.h"
+#include "CAFAna/Core/Utilities.h"
 
 #include "OscLib/func/IOscCalculator.h"
 
@@ -63,6 +64,16 @@ namespace ana
 
       virtual void operator()(const std::vector<double>& state) { fSamples.AddSample(state); }
       virtual void operator()(const std::vector<std::string>& names) { fSamples.SetNames(names); }
+
+      template <typename Model, typename RNG>
+      void SaveSamplerState(stan::mcmc::adapt_diag_e_nuts<Model, RNG> &sampler)
+      {
+        // this is from Stan
+        sampler.write_sampler_state(*this);
+
+        fSamples.SetHyperparams(sampler.get_nominal_stepsize(),  // the 'nominal' stepsize is updated at the end of warmup
+                                TMatrixDFromEigenMatrixXd(sampler.z().inv_e_metric_));
+      }
 
 
     private:

--- a/CAFAna/Fit/StanFitter.h
+++ b/CAFAna/Fit/StanFitter.h
@@ -77,8 +77,8 @@ namespace ana
       // and only overloading the one we care about
       using stan::callbacks::writer::operator();
 
-      virtual void operator()(const std::vector<double>& state) { fSamples.AddSample(state); }
-      virtual void operator()(const std::vector<std::string>& names) { fSamples.SetNames(names); }
+      void operator()(const std::vector<double>& state) override { fSamples.AddSample(state); }
+      void operator()(const std::vector<std::string>& names) override { fSamples.SetNames(names); }
 
       template <typename Model, typename RNG>
       void SaveSamplerState(stan::mcmc::adapt_diag_e_nuts<Model, RNG> &sampler)

--- a/CAFAna/Fit/StanFitter.h
+++ b/CAFAna/Fit/StanFitter.h
@@ -4,6 +4,8 @@
 #include <map>
 #include <vector>
 
+#include "boost/random.hpp"
+
 #include "CAFAna/Core/FwdDeclare.h"
 #include "CAFAna/Core/IFitVar.h"
 #include "CAFAna/Core/Progress.h"
@@ -35,6 +37,12 @@
 
 namespace stan
 {
+  namespace callbacks
+  {
+    class logger;
+    class stream_logger;
+  }
+
   namespace io
   {
     class var_context;
@@ -42,6 +50,13 @@ namespace stan
     template<typename T>
     class writer;
   }
+
+  namespace mcmc
+  {
+    template <typename Model, typename RNG>
+    class adapt_diag_e_nuts;
+  }
+
 }
 
 namespace ana

--- a/CAFAna/Fit/StanFitter.h
+++ b/CAFAna/Fit/StanFitter.h
@@ -217,6 +217,11 @@ namespace ana
         return std::make_unique<MCMCSamples>(std::move(ws == MemoryTupleWriter::WhichSamples::kWarmup ? fMCMCWarmup : fMCMCSamples));
       }
 
+      /// Supply samples and hyperparameters from a previously run warmup of MCMC.
+      /// Burden is on the user to ensure they are compatible with the sampling required.
+      /// (Call this prior to calling Fit() in order to use it.)
+      void ReuseWarmup(MCMCSamples && warmup);
+
       /// Change the config used for Stan.  See the StanConfig struct documentation for ideas
       void SetStanConfig(const StanConfig& cfg) { fStanConfig = cfg; }
 

--- a/CAFAna/Fit/StanFitter.h
+++ b/CAFAna/Fit/StanFitter.h
@@ -297,6 +297,42 @@ namespace ana
                                                    SystShifts &systSeed,
                                                    Verbosity verb) const override;
 
+      /// Run Stan with HMC.
+      /// Lots of copy-paste from stan::services::sample::hmc_nuts_diag_e_adapt()
+      /// (in stan/services/sample/hmc_nuts_diag_e_adapt.hpp)
+      /// so that we can customize in order to save the sampler state after warmup is finished.
+      ///
+      /// \param init_writer    Stream to write initialization info to
+      /// \param interrupt      Object whose operator()() will be called after every sample
+      /// \param diagStream     Stream to write diagnostic info to
+      /// \param logger         General object to write log to
+      /// \param init_context   MCMC initialization info
+      /// \param procId         Process ID
+      /// \return               Stan return code
+      int RunHMC(stan::callbacks::writer &init_writer,
+                 StanFitter::samplecounter_callback &interrupt,
+                 std::ostream &diagStream,
+                 const std::unique_ptr<stan::callbacks::stream_logger> &logger,
+                 stan::io::array_var_context &init_context,
+                 unsigned int procId) const;
+
+      /// Run the HMC sampler explicitly.
+      /// Cribbed from stan::services::run_adaptive_sampler() (in stan/services/util/run_adaptive_sampler.hpp)
+      /// in order to insert save/restore state code after warmup is done.
+      ///
+      /// \param sampler             The MCMC sampler object to use.  (In Stan this is a templated type, but we'll only ever use this version)
+      /// \param cont_vector         Starting parameter values (transformed into Stan's internal working space)
+      /// \param rng                 The random number generator being used
+      /// \param interrupt           Object whose operator()() will be called after every sample
+      /// \param logger              General object to write log to
+      /// \param diagnostic_writer   Object to write diagnostics to
+      void RunSampler(stan::mcmc::adapt_diag_e_nuts<StanFitter, boost::ecuyer1988>& sampler,
+                      std::vector<double>& cont_vector,
+                      boost::ecuyer1988& rng,
+                      stan::callbacks::interrupt& interrupt,
+                      stan::callbacks::logger& logger,
+                      stan::callbacks::writer& diagnostic_writer) const;
+
       /// Helper function that actually does the unconstraining Stan needs
       template <typename T>
       void transform_helper(const stan::io::var_context& context,

--- a/CAFAna/test/test_stanfit_dummy.C
+++ b/CAFAna/test/test_stanfit_dummy.C
@@ -123,6 +123,10 @@ void test_stanfit_dummy()
   c.Clear();
   const_cast<TTree*>(fitter.GetSamples().ToTTree())->Draw("QuadraticParameter");
   c.SaveAs("test_stanfit_samples.png");
+
+  TFile outF("test_stanfit_samples.root", "recreate");
+  fitter.GetSamples(MemoryTupleWriter::WhichSamples::kWarmup).SaveTo(&outF, "warmup");
+  fitter.GetSamples(MemoryTupleWriter::WhichSamples::kPostWarmup).SaveTo(&outF, "samples");
 }
 
 #ifndef __CINT__

--- a/CAFAna/test/test_stanfit_statsonly.C
+++ b/CAFAna/test/test_stanfit_statsonly.C
@@ -126,6 +126,7 @@ void test_stanfit_statsonly(bool loadPredFromFile=true, bool savePredToFile=fals
   ana::ConstrainedFitVarWithPrior fitDmSq32Scaled_UniformPrior(&ana::kFitDmSq32Scaled, ana::PriorUniformInFitVar, "FlatDmSq32");
 
   std::unique_ptr<ana::MCMCSamples> samples;
+  std::unique_ptr<ana::MCMCSamples> warmup;
   if (!loadSamplesFromFile)
   {
     ana::StanFitter fitter(&expt, {&fitSsqTh23_UniformPriorSsqTh23, &fitDmSq32Scaled_UniformPrior}, {});
@@ -138,11 +139,13 @@ void test_stanfit_statsonly(bool loadPredFromFile=true, bool savePredToFile=fals
     fitter.SetStanConfig(config);
     ana::SystShifts systs;
     fitter.Fit(calc.get(), systs);
-    samples = fitter.ExtractSamples();
+    warmup =  fitter.ExtractSamples(ana::MemoryTupleWriter::WhichSamples::kWarmup);
+    samples = fitter.ExtractSamples(ana::MemoryTupleWriter::WhichSamples::kPostWarmup);
 
     if (saveSamplesToFile)
     {
       TFile outf( (workDir + "/mcmcsamples.root").c_str(), "recreate");
+      warmup->SaveTo(&outf, "warmup");
       samples->SaveTo(&outf, "samples");
     }
   }


### PR DESCRIPTION
These commits intersect the Stan plumbing a bit further into the guts in order to implement persistence and resumption of the MCMC state immediately after the warmup phase completes.  Because MCMC ideally has no "memory" (i.e., subsequent steps depend only on the one immediately preceding them) this improvement allows a user to use a single warmup run (which can be very long in wallclock time) to initialize numerous "full sample" chains, which can then be run in parallel.

Unfortunately using the Stan plumbing introduces a bit more dependence on the details of the Stan interfaces.  I think we are unlikely to be upgrading Stan frequently, and Stan is already a mature codebase, so this is hopefully not a big deal.