### PR TITLE
Feature/ext_cafanacore_v15

### DIFF
--- a/CAFAna/.gitignore
+++ b/CAFAna/.gitignore
@@ -1,6 +1,7 @@
 *_C_ACLiC_dict_rdict.pcm
 build/
-cmake/
+cmake/CMakeCache.txt
+cmake/CMakeFiles/
 *.d
 *.so
 *.root

--- a/CAFAna/.gitignore
+++ b/CAFAna/.gitignore
@@ -4,3 +4,5 @@ cmake/
 *.d
 *.so
 *.root
+*.pdf
+*.png

--- a/CAFAna/Analysis/Calcs.cxx
+++ b/CAFAna/Analysis/Calcs.cxx
@@ -1,6 +1,8 @@
 #include "CAFAna/Analysis/Calcs.h"
 #include "CAFAna/Analysis/CalcsVars.h"
 
+#include "OscLib/IOscCalc.h"
+
 #include "OscLib/OscCalcPMNSOpt.h"
 #include "OscLib/OscCalcSterile.h"
 #include "OscLib/OscCalcGeneral.h"
@@ -53,7 +55,7 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
-  void ResetSterileCalcToDefault(osc::OscCalcSterile* calc)
+  void ResetSterileCalcToDefault(osc::IOscCalcSterile* calc)
   {
     osc::OscCalcPMNSOpt* tmp = new osc::OscCalcPMNSOpt();
     ResetOscCalcToDefault(tmp);
@@ -74,7 +76,7 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
-  osc::OscCalcSterile* DefaultSterileCalc(int nflavors)
+  osc::IOscCalcSterile* DefaultSterileCalc(int nflavors)
   {
     osc::OscCalcSterile* ret = new osc::OscCalcSterile;
 

--- a/CAFAna/Analysis/Calcs.h
+++ b/CAFAna/Analysis/Calcs.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "OscLib/IOscCalc.h"
-
-namespace osc{class OscCalcSterile;}
+#include "CAFAna/Core/OscCalcFwdDeclare.h"
 
 namespace ana
 {
@@ -15,8 +13,8 @@ namespace ana
   osc::IOscCalcAdjustable* DefaultOscCalcIH();
 
   /// Reset calculator to default assumptions for all parameters
-  void ResetSterileCalcToDefault(osc::OscCalcSterile* calc);
+  void ResetSterileCalcToDefault(osc::IOscCalcSterile* calc);
 
   /// Create a sterile calculator with default assumptions for all parameters
-  osc::OscCalcSterile* DefaultSterileCalc(int nflavors);
+  osc::IOscCalcSterile* DefaultSterileCalc(int nflavors);
 }

--- a/CAFAna/Analysis/Calcs.h
+++ b/CAFAna/Analysis/Calcs.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "CAFAna/Core/FwdDeclare.h"
+#include "OscLib/IOscCalc.h"
 
 namespace osc{class OscCalcSterile;}
 

--- a/CAFAna/Analysis/CalcsNuFit.cxx
+++ b/CAFAna/Analysis/CalcsNuFit.cxx
@@ -9,6 +9,8 @@
 
 #include "TFormula.h"
 
+#include <iostream>
+
 namespace ana
 {
   std::vector<std::pair<std::string, double> > ParseAsimovSet(std::string noApologies){

--- a/CAFAna/Analysis/Plots.h
+++ b/CAFAna/Analysis/Plots.h
@@ -6,10 +6,10 @@
 #include "Rtypes.h"
 
 #include "CAFAna/Core/FwdDeclare.h"
-#include "CAFAna/Core/Utilities.h"
 #include "CAFAna/Core/SystShifts.h"
+#include "CAFAna/Core/Utilities.h"
 
-#include "OscLib/OscCalc.h"
+#include "CAFAna/Core/OscCalcFwdDeclare.h"
 
 class TLegend;
 class TGraph;

--- a/CAFAna/Analysis/Plots.h
+++ b/CAFAna/Analysis/Plots.h
@@ -9,6 +9,8 @@
 #include "CAFAna/Core/Utilities.h"
 #include "CAFAna/Core/SystShifts.h"
 
+#include "OscLib/OscCalc.h"
+
 class TLegend;
 class TGraph;
 class TGraphAsymmErrors;

--- a/CAFAna/CMakeLists.txt
+++ b/CAFAna/CMakeLists.txt
@@ -77,6 +77,8 @@ include_directories(
 
 find_library(CAFANACOREEXT CAFAnaCoreExt $ENV{CAFANACORE_LIB})
 
+find_library(TBB tbb $ENV{TBB_LIB})
+
 LIST(APPEND EXTRA_CXX_FLAGS -DDONT_USE_SAM=1 -DUSE_CAFANA_ENVVAR=1 -DDONT_USE_FQ_HARDCODED_SYST_PATHS=1 -DALLOW_XROOTD_PATH_THROUGH_WILDCARDSOURCE=1)
 
 include(${CMAKE_SOURCE_DIR}/cmake/c++CompilerSetup.cmake)
@@ -91,6 +93,7 @@ set(StandardRecord_implementation_files
 set(StandardRecord_header_files
     ${SRC_ROOT_PARENT}/StandardRecord/StandardRecord.h
     ${SRC_ROOT_PARENT}/StandardRecord/SRProxy.h
+    ${SRC_ROOT_PARENT}/StandardRecord/FwdDeclare.h
 )
 
 add_library(StandardRecord SHARED ${StandardRecord_implementation_files})

--- a/CAFAna/Core/CMakeLists.txt
+++ b/CAFAna/Core/CMakeLists.txt
@@ -18,12 +18,15 @@ set(Core_implementation_files
 
 set(Core_header_files
   Binning.h
+  Cut.h
   FitVarWithPrior.h
+  HistAxis.h
   IFitVar.h
   ISyst.h
   Loaders.h
   LoadFromFile.h
   MathUtil.h
+  MultiVar.h
   OscCurve.h
   OscillatableSpectrum.h
   Registry.h
@@ -33,6 +36,7 @@ set(Core_header_files
   StanUtils.h
   SystShifts.h
   Utilities.h
+  Var.h
   ModeConversionUtilities.h
   rootlogon.C)
 

--- a/CAFAna/Core/CMakeLists.txt
+++ b/CAFAna/Core/CMakeLists.txt
@@ -27,6 +27,7 @@ set(Core_header_files
   LoadFromFile.h
   MathUtil.h
   MultiVar.h
+  OscCalcFwdDeclare.h
   OscCurve.h
   OscillatableSpectrum.h
   Registry.h
@@ -41,7 +42,7 @@ set(Core_header_files
   rootlogon.C)
 
 add_library(CAFAnaCore SHARED ${Core_implementation_files})
-target_link_libraries(CAFAnaCore ${CAFANACOREEXT})
+target_link_libraries(CAFAnaCore ${CAFANACOREEXT} ${TBB})
 
 if(DEFINED USE_GPERFTOOLS AND USE_GPERFTOOLS)
   add_dependencies(CAFAnaCore gperftools)

--- a/CAFAna/Core/Cut.h
+++ b/CAFAna/Core/Cut.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "CAFAnaCore/CAFAna/Core/Cut.h"
+
+namespace caf{
+  template<class T> class Proxy;
+  class StandardRecord;
+  typedef Proxy<StandardRecord> SRProxy;
+}
+
+namespace ana
+{
+  typedef _Cut<caf::SRProxy> Cut;
+
+  /// The simplest possible cut: pass everything, used as a default
+  const Cut kNoCut(NoCut<caf::SRProxy>{});
+}

--- a/CAFAna/Core/Cut.h
+++ b/CAFAna/Core/Cut.h
@@ -2,15 +2,11 @@
 
 #include "CAFAnaCore/CAFAna/Core/Cut.h"
 
-namespace caf{
-  template<class T> class Proxy;
-  class StandardRecord;
-  typedef Proxy<StandardRecord> SRProxy;
-}
+#include "StandardRecord/FwdDeclare.h"
 
 namespace ana
 {
-  typedef _Cut<caf::SRProxy> Cut;
+  using Cut = _Cut<caf::SRProxy>;
 
   /// The simplest possible cut: pass everything, used as a default
   const Cut kNoCut(NoCut<caf::SRProxy>{});

--- a/CAFAna/Core/HistAxis.h
+++ b/CAFAna/Core/HistAxis.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "CAFAnaCore/CAFAna/Core/HistAxis.h"
+
+#include "CAFAna/Core/Var.h"
+
+namespace ana
+{
+  typedef _HistAxis<Var> HistAxis;
+}

--- a/CAFAna/Core/IFitVar.h
+++ b/CAFAna/Core/IFitVar.h
@@ -2,14 +2,12 @@
 
 #include <string>
 
-#include "CAFAna/Core/FwdDeclare.h"
+#include "CAFAna/Core/OscCalcFwdDeclare.h"
 #include "CAFAna/Core/Registry.h"
 #include "CAFAna/Core/StanTypedefs.h"
 #include "CAFAna/Core/StanVar.h"
 
 #include "CAFAna/Core/StanUtils.h"
-
-#include "OscLib/OscCalc.h"
 
 namespace ana
 {

--- a/CAFAna/Core/IFitVar.h
+++ b/CAFAna/Core/IFitVar.h
@@ -9,6 +9,8 @@
 
 #include "CAFAna/Core/StanUtils.h"
 
+#include "OscLib/OscCalc.h"
+
 namespace ana
 {
   //----------------------------------------------------------------------

--- a/CAFAna/Core/ISyst.h
+++ b/CAFAna/Core/ISyst.h
@@ -2,14 +2,10 @@
 
 #include "CAFAna/Core/FwdDeclare.h"
 
+#include "StandardRecord/FwdDeclare.h"
+
 #include <list>
 #include <string>
-
-namespace caf{
-  template<class T> class Proxy;
-  class StandardRecord;
-  typedef Proxy<StandardRecord> SRProxy;
-}
 
 namespace ana
 {

--- a/CAFAna/Core/ISyst.h
+++ b/CAFAna/Core/ISyst.h
@@ -5,6 +5,12 @@
 #include <list>
 #include <string>
 
+namespace caf{
+  template<class T> class Proxy;
+  class StandardRecord;
+  typedef Proxy<StandardRecord> SRProxy;
+}
+
 namespace ana
 {
   class Restorer;

--- a/CAFAna/Core/LoadFromFile.h
+++ b/CAFAna/Core/LoadFromFile.h
@@ -8,6 +8,7 @@
 #include "TFile.h"
 
 #include "CAFAna/Core/FwdDeclare.h"
+#include "OscLib/OscCalc.h"
 
 class TDirectory;
 

--- a/CAFAna/Core/LoadFromFile.h
+++ b/CAFAna/Core/LoadFromFile.h
@@ -7,8 +7,7 @@
 
 #include "TFile.h"
 
-#include "CAFAna/Core/FwdDeclare.h"
-#include "OscLib/OscCalc.h"
+#include "CAFAna/Core/OscCalcFwdDeclare.h"
 
 class TDirectory;
 

--- a/CAFAna/Core/MultiVar.h
+++ b/CAFAna/Core/MultiVar.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "CAFAnaCore/CAFAna/Core/MultiVar.h"
+
+namespace caf{
+  template<class T> class Proxy;
+  class StandardRecord;
+  typedef Proxy<StandardRecord> SRProxy;
+}
+
+namespace ana
+{
+  typedef _MultiVar<caf::SRProxy> MultiVar;
+}

--- a/CAFAna/Core/MultiVar.h
+++ b/CAFAna/Core/MultiVar.h
@@ -2,11 +2,7 @@
 
 #include "CAFAnaCore/CAFAna/Core/MultiVar.h"
 
-namespace caf{
-  template<class T> class Proxy;
-  class StandardRecord;
-  typedef Proxy<StandardRecord> SRProxy;
-}
+#include "StandardRecord/FwdDeclare.h"
 
 namespace ana
 {

--- a/CAFAna/Core/OscCalcFwdDeclare.h
+++ b/CAFAna/Core/OscCalcFwdDeclare.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace osc
+{
+  template<class T> class _IOscCalc;
+  template<class T> class _IOscCalcAdjustable;
+
+  typedef _IOscCalc<double> IOscCalc;
+  typedef _IOscCalcAdjustable<double> IOscCalcAdjustable;
+
+  class IOscCalcSterile;
+}

--- a/CAFAna/Core/OscCurve.h
+++ b/CAFAna/Core/OscCurve.h
@@ -1,11 +1,9 @@
 #pragma once
 
-#include "CAFAna/Core/FwdDeclare.h"
+#include "CAFAna/Core/OscCalcFwdDeclare.h"
 #include "CAFAna/Core/StanTypedefs.h"
 
 #include "CAFAna/Core/Ratio.h"
-
-#include "OscLib/OscCalc.h"
 
 namespace ana
 {

--- a/CAFAna/Core/OscCurve.h
+++ b/CAFAna/Core/OscCurve.h
@@ -5,6 +5,8 @@
 
 #include "CAFAna/Core/Ratio.h"
 
+#include "OscLib/OscCalc.h"
+
 namespace ana
 {
   /// Transition probability for any one channel as a function of energy

--- a/CAFAna/Core/OscillatableSpectrum.h
+++ b/CAFAna/Core/OscillatableSpectrum.h
@@ -9,6 +9,8 @@
 #include "CAFAna/Core/StanTypedefs.h"
 #include "CAFAna/Core/ThreadLocal.h"
 
+#include "OscLib/OscCalc.h"
+
 #include <string>
 
 #include "TMD5.h"

--- a/CAFAna/Core/OscillatableSpectrum.h
+++ b/CAFAna/Core/OscillatableSpectrum.h
@@ -4,12 +4,11 @@
 
 #include "CAFAna/Core/Binning.h"
 #include "CAFAna/Core/FwdDeclare.h"
+#include "CAFAna/Core/OscCalcFwdDeclare.h"
 #include "CAFAna/Core/Spectrum.h"
 #include "CAFAna/Core/SpectrumLoaderBase.h"
 #include "CAFAna/Core/StanTypedefs.h"
 #include "CAFAna/Core/ThreadLocal.h"
-
-#include "OscLib/OscCalc.h"
 
 #include <string>
 

--- a/CAFAna/Core/SpectrumLoader.cxx
+++ b/CAFAna/Core/SpectrumLoader.cxx
@@ -585,9 +585,6 @@ void SpectrumLoader::ReportExposures() {
   std::cout << fPOT << " POT" << std::endl;
 }
 
-//----------------------------------------------------------------------
-void SpectrumLoader::AccumulateExposures(const caf::SRSpill *spill) {}
-
 // cafanacore's spectra are expecting a different structure of
 // spectrumloader. But we can easily trick it with these.
 struct SpectrumSink

--- a/CAFAna/Core/SpectrumLoader.h
+++ b/CAFAna/Core/SpectrumLoader.h
@@ -44,8 +44,6 @@ namespace ana
     SpectrumLoader(const SpectrumLoader&) = delete;
     SpectrumLoader& operator=(const SpectrumLoader&) = delete;
 
-    void AccumulateExposures(const caf::SRSpill* spill) override;
-
     virtual void HandleFile(TFile* f, Progress* prog = 0);
 
     virtual void HandleRecord(caf::StandardRecord* sr);

--- a/CAFAna/Core/SpectrumLoaderBase.h
+++ b/CAFAna/Core/SpectrumLoaderBase.h
@@ -82,8 +82,6 @@ namespace ana
     /// Figure out if \a str is a wildcard or SAM query and return a source
     IFileSource* WildcardOrSAMQuery(const std::string& str) const;
 
-    virtual void AccumulateExposures(const caf::SRSpill* spill) = 0;
-
     /// Forwards to \ref fFileSource
     int NFiles() const;
 
@@ -200,8 +198,6 @@ namespace ana
                                  const Cut& cut,
                                  const SystShifts& shift,
                                  const Var& wei) override {}
-
-    void AccumulateExposures(const caf::SRSpill* spill) override {};
   };
   /// \brief Dummy loader that doesn't load any files
   ///

--- a/CAFAna/Core/StanTypedefs.h
+++ b/CAFAna/Core/StanTypedefs.h
@@ -6,11 +6,13 @@
 ///    and it's much easier to maintain if it's in a single place.
 #pragma once
 
+#include "stan/math/rev/core/var_value_fwd_declare.hpp"
+
 namespace stan
 {
   namespace math
   {
-    class var;
+    typedef var_value<double> var;
   }
 }
 

--- a/CAFAna/Core/SystShifts.h
+++ b/CAFAna/Core/SystShifts.h
@@ -13,12 +13,6 @@
 
 class TDirectory;
 
-namespace caf{
-  template<class T> class Proxy;
-  class StandardRecord;
-  typedef Proxy<StandardRecord> SRProxy;
-}
-
 namespace ana
 {
   class ISyst;

--- a/CAFAna/Core/SystShifts.h
+++ b/CAFAna/Core/SystShifts.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CAFAna/Core/FwdDeclare.h"
+#include "StandardRecord/FwdDeclare.h"
 
 #include "CAFAna/Core/StanVar.h"
 

--- a/CAFAna/Core/SystShifts.h
+++ b/CAFAna/Core/SystShifts.h
@@ -12,6 +12,12 @@
 
 class TDirectory;
 
+namespace caf{
+  template<class T> class Proxy;
+  class StandardRecord;
+  typedef Proxy<StandardRecord> SRProxy;
+}
+
 namespace ana
 {
   class ISyst;

--- a/CAFAna/Core/Utilities.cxx
+++ b/CAFAna/Core/Utilities.cxx
@@ -1,6 +1,8 @@
+// Need to get a stan include in before the eigen ones in the header
+#include "CAFAna/Core/Spectrum.h"
+
 #include "CAFAna/Core/Utilities.h"
 
-#include "CAFAna/Core/Spectrum.h"
 #include "CAFAna/Core/Ratio.h"
 
 #include "CAFAna/Core/MathUtil.h"

--- a/CAFAna/Core/Var.h
+++ b/CAFAna/Core/Var.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "CAFAnaCore/CAFAna/Core/Var.h"
+
+namespace caf{
+  template<class T> class Proxy;
+  class StandardRecord;
+  typedef Proxy<StandardRecord> SRProxy;
+}
+
+namespace ana
+{
+  /// \brief Representation of a variable to be retrieved from a \ref
+  /// caf::StandardRecord object
+  ///
+  /// A Var consists of a function, taking a StandardRecord and returning the
+  /// value of the variable (which may be some complicated function).
+  typedef _Var<caf::SRProxy> Var;
+
+  /// \brief For Vars where literally all you need is a single CAF variable
+  ///
+  /// eg Var myVar = SIMPLEVAR(my.var.str);
+  /// NB lack of quotes quotes around my.var.str
+#define SIMPLEVAR(CAFNAME) Var([](const caf::SRProxy* sr){return sr->CAFNAME;})
+
+  /// The simplest possible Var, always 1. Used as a default weight.
+  const Var kUnweighted = Unweighted<caf::SRProxy>();
+
+  inline Var Constant(double v){return Var([v](const caf::SRProxy*){return v;});}
+}

--- a/CAFAna/Core/Var.h
+++ b/CAFAna/Core/Var.h
@@ -2,11 +2,7 @@
 
 #include "CAFAnaCore/CAFAna/Core/Var.h"
 
-namespace caf{
-  template<class T> class Proxy;
-  class StandardRecord;
-  typedef Proxy<StandardRecord> SRProxy;
-}
+#include "StandardRecord/FwdDeclare.h"
 
 namespace ana
 {
@@ -15,7 +11,7 @@ namespace ana
   ///
   /// A Var consists of a function, taking a StandardRecord and returning the
   /// value of the variable (which may be some complicated function).
-  typedef _Var<caf::SRProxy> Var;
+  using Var = _Var<caf::SRProxy>;
 
   /// \brief For Vars where literally all you need is a single CAF variable
   ///

--- a/CAFAna/Experiment/CovarianceExperiment.cxx
+++ b/CAFAna/Experiment/CovarianceExperiment.cxx
@@ -8,6 +8,9 @@
 
 #include "OscLib/IOscCalc.h"
 
+#include "TFile.h"
+#include "TDirectory.h"
+
 namespace ana
 {
   //----------------------------------------------------------------------

--- a/CAFAna/Experiment/IExperiment.cxx
+++ b/CAFAna/Experiment/IExperiment.cxx
@@ -1,5 +1,6 @@
 #include "CAFAna/Experiment/IExperiment.h"
 
+#include "CAFAna/Core/LoadFromFile.h"
 #include "CAFAna/Core/Utilities.h"
 
 #include "TFile.h"

--- a/CAFAna/Experiment/IExperiment.h
+++ b/CAFAna/Experiment/IExperiment.h
@@ -1,10 +1,8 @@
 #pragma once
 
-#include "CAFAna/Core/FwdDeclare.h"
+#include "CAFAna/Core/OscCalcFwdDeclare.h"
 #include "CAFAna/Core/StanTypedefs.h"
 #include "CAFAna/Core/SystShifts.h"
-#include "CAFAna/Core/LoadFromFile.h"
-#include "CAFAna/Core/Stan.h"
 
 class TDirectory;
 

--- a/CAFAna/Experiment/MultiExperiment.cxx
+++ b/CAFAna/Experiment/MultiExperiment.cxx
@@ -3,6 +3,7 @@
 #include "CAFAna/Core/Utilities.h"
 
 #include "CAFAna/Core/LoadFromFile.h"
+#include "CAFAna/Core/Stan.h"
 
 #include "OscLib/IOscCalc.h"
 

--- a/CAFAna/Experiment/SingleSampleExperiment.cxx
+++ b/CAFAna/Experiment/SingleSampleExperiment.cxx
@@ -1,6 +1,7 @@
 #include "CAFAna/Experiment/SingleSampleExperiment.h"
 
 #include "CAFAna/Core/LoadFromFile.h"
+#include "CAFAna/Core/Stan.h"
 #include "CAFAna/Core/StanUtils.h"
 #include "CAFAna/Core/Utilities.h"
 

--- a/CAFAna/Experiment/SolarConstraints.cxx
+++ b/CAFAna/Experiment/SolarConstraints.cxx
@@ -8,6 +8,7 @@
 #include "TObjString.h"
 
 #include <cassert>
+#include <iostream>
 
 namespace ana
 {

--- a/CAFAna/Fit/BayesianMarginal.cxx
+++ b/CAFAna/Fit/BayesianMarginal.cxx
@@ -5,6 +5,7 @@
 #include "TH3D.h"
 #include "TFile.h"
 #include "TMap.h"
+#include "TObjString.h"
 #include "TParameter.h"
 #include "TSystem.h"
 #include "TMVA/Config.h"

--- a/CAFAna/Fit/BayesianSurface.cxx
+++ b/CAFAna/Fit/BayesianSurface.cxx
@@ -1,4 +1,4 @@
-
+#include "TObjString.h"
 #include "TH2F.h"
 
 #include "CAFAna/Core/Binning.h"

--- a/CAFAna/Fit/MCMCSamples.cxx
+++ b/CAFAna/Fit/MCMCSamples.cxx
@@ -3,6 +3,8 @@
 #include <vector>
 
 #include "TH1D.h"
+#include "TKey.h"
+#include "TObjString.h"
 #include "TParameter.h"
 
 #include "CAFAna/Core/IFitVar.h"

--- a/CAFAna/Fit/Priors.cxx
+++ b/CAFAna/Fit/Priors.cxx
@@ -1,8 +1,9 @@
 #include "CAFAna/Fit/Priors.h"
-#include "CAFAna/Core//Stan.h"
 
-#include "stan/math/prim/scal/prob/normal_lpdf.hpp"
-#include "stan/math/prim/scal/fun/erf.hpp"
+#include "CAFAna/Core/Stan.h"
+
+#include "stan/math/prim/prob/normal_lpdf.hpp"
+#include "stan/math/prim/fun/erf.hpp"
 
 namespace ana
 {

--- a/CAFAna/Fit/SeedList.h
+++ b/CAFAna/Fit/SeedList.h
@@ -2,6 +2,8 @@
 
 #include "CAFAna/Core/FwdDeclare.h"
 
+#include "OscLib/OscCalc.h"
+
 #include <iostream>
 #include <map>
 #include <set>

--- a/CAFAna/Fit/SeedList.h
+++ b/CAFAna/Fit/SeedList.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "CAFAna/Core/FwdDeclare.h"
-
-#include "OscLib/OscCalc.h"
+#include "CAFAna/Core/OscCalcFwdDeclare.h"
 
 #include <iostream>
 #include <map>

--- a/CAFAna/Fit/StanFitter.cxx
+++ b/CAFAna/Fit/StanFitter.cxx
@@ -7,6 +7,8 @@
 #pragma GCC diagnostic ignored "-Wmisleading-indentation"
 #endif
 #pragma GCC diagnostic ignored "-Wunused-function"
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#pragma GCC diagnostic ignored "-Wignored-qualifiers"
 #include "stan/callbacks/stream_logger.hpp"
 #include "stan/callbacks/stream_writer.hpp"
 #include "stan/io/reader.hpp"

--- a/CAFAna/Systs/SystComponentScale.cxx
+++ b/CAFAna/Systs/SystComponentScale.cxx
@@ -2,6 +2,7 @@
 
 #include "CAFAna/Systs/DUNEXSecSysts.h"
 
+#include "TDirectory.h"
 #include "TObjString.h"
 
 #include <cmath>

--- a/CAFAna/cmake/ups_env_setup.sh
+++ b/CAFAna/cmake/ups_env_setup.sh
@@ -7,17 +7,18 @@ if [ -z "${UPS_SHELL}" ]; then
   exit 1
 fi
 
-setup root v6_18_04d -q e19:prof || exit 1
-setup boost v1_70_0 -q e19:prof || exit 1
+setup root v6_22_06a -q e19:prof:p383b || exit 1
+setup boost v1_73_0 -q e19:prof || exit 1
 setup cmake v3_12_2 || exit 1
 setup jobsub_client || exit 1
 
 setup clhep v2_4_1_2 -q e19:prof || exit 1
 
-setup stan v2_18_0a -q e19:prof || exit 1
+setup eigen v3_3_9a || exit
+setup stan v2_26_1 -q e19:prof || exit 1
 
-setup osclib v00.09 -q e19:prof:stan || exit 1
-setup cafanacore v01.11 -q e19:prof || exit 1
+setup osclib v00.14 -q e19:prof:n309:stan || exit 1
+setup cafanacore v01.15 -q e19:prof:n309 || exit 1
 
 # To get setup_fnal_security which helps reading files over xrootd
-setup duneutil v09_09_02 -q e19:prof
+setup duneutil v09_21_00 -q e19:prof

--- a/StandardRecord/FwdDeclare.h
+++ b/StandardRecord/FwdDeclare.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace caf
+{
+  class StandardRecord;
+  template<class T> class Proxy;
+  typedef Proxy<StandardRecord> SRProxy;
+}


### PR DESCRIPTION
Update to the latest cafanacore and osclib, which also use a much newer version of stan. This catches us up to the versions of everything that current larsoft uses. The new cafanacore has the nice property that it no longer knows anything at all about the existence of the `StandardRecord` class - hence why we have to declare a few more things for ourselves.

I tested this with `tute/demo7.C` and that still works fine. I made a PR rather than just merging it because
1. I want to be sure in advance it won't mess up something in the PRISM branch
2. I'm embarrassed how I linked to `libtbb` (and actually `libCAFAnaCoreExt` which was already there like that). What's the right way to do this?

The new stan triggers a deprecation warning in the new tbb which is quite persistent. I have a fix in upstream cafanacore, but it doesn't quite seem worth making a release with a one line change to shut up a warning.