### PR TITLE
Port in nova treatment of NC prediction component.

### DIFF
--- a/CAFAna/Extrap/IExtrap.h
+++ b/CAFAna/Extrap/IExtrap.h
@@ -41,7 +41,9 @@ namespace ana
     virtual OscillatableSpectrum AntiTauFromMuComponent() = 0;
 
     /// Neutral currents
+    virtual Spectrum NCTotalComponent() = 0;
     virtual Spectrum NCComponent() = 0;
+    virtual Spectrum NCAntiComponent() = 0;
 
     virtual void SaveTo(TDirectory* dir, const std::string& name) const;
   };

--- a/CAFAna/Extrap/TrivialExtrap.cxx
+++ b/CAFAna/Extrap/TrivialExtrap.cxx
@@ -36,13 +36,19 @@ namespace ana
     fTauFromMu    (loaderNuTau,   axis, cut && kIsTauFromMu && !kIsAntiNu, shift, wei),
     fTauFromMuAnti(loaderNuTau,   axis, cut && kIsTauFromMu &&  kIsAntiNu, shift, wei),
 
-    fNC           (loaderNonswap, axis, cut && kIsNC,                      shift, wei)
+    fNCTot        (loaderNonswap, axis, cut && kIsNC                     , shift, wei),
+    fNC           (loaderNonswap, axis, cut && kIsNC        && !kIsAntiNu, shift, wei),
+    fNCAnti       (loaderNonswap, axis, cut && kIsNC        &&  kIsAntiNu, shift, wei)
   {
     // All swapped files are equally valid as a source of NCs. This
     // approximately doubles/triples our statistics. SpectrumLoader just adds
     // events and POT for both cases, which is the right thing to do.
-    loaderNue  .AddSpectrum(fNC, axis.GetVar1D(), cut && kIsNC, shift, wei);
-    loaderNuTau.AddSpectrum(fNC, axis.GetVar1D(), cut && kIsNC, shift, wei);
+    loaderNue  .AddSpectrum(fNCTot , axis.GetVar1D(), cut && kIsNC              , shift, wei);
+    loaderNue  .AddSpectrum(fNC    , axis.GetVar1D(), cut && kIsNC && !kIsAntiNu, shift, wei);
+    loaderNue  .AddSpectrum(fNCAnti, axis.GetVar1D(), cut && kIsNC &&  kIsAntiNu, shift, wei);
+    loaderNuTau.AddSpectrum(fNCTot , axis.GetVar1D(), cut && kIsNC              , shift, wei);
+    loaderNuTau.AddSpectrum(fNC    , axis.GetVar1D(), cut && kIsNC && !kIsAntiNu, shift, wei);
+    loaderNuTau.AddSpectrum(fNCAnti, axis.GetVar1D(), cut && kIsNC &&  kIsAntiNu, shift, wei);
   }
 
 
@@ -100,7 +106,9 @@ namespace ana
 
     fNueApp.SaveTo(dir, "nue_app");
     fNueAppAnti.SaveTo(dir, "nue_app_anti");
+    fNCTot.SaveTo(dir, "nc_tot");
     fNC.SaveTo(dir, "nc");
+    fNCAnti.SaveTo(dir, "nc_anti");
     fNumuSurv.SaveTo(dir, "numu_surv");
     fNumuSurvAnti.SaveTo(dir, "numu_surv_anti");
     fNumuApp.SaveTo(dir, "numu_app");
@@ -139,7 +147,9 @@ namespace ana
     ret->fTauFromMu     = *OscillatableSpectrum::LoadFrom(dir, "nutau_from_numu");
     ret->fTauFromMuAnti = *OscillatableSpectrum::LoadFrom(dir, "nutau_from_numu_anti");
 
-    ret->fNC = *Spectrum::LoadFrom(dir, "nc");
+    ret->fNCTot  = *Spectrum::LoadFrom(dir, "nc_tot");
+    ret->fNC     = *Spectrum::LoadFrom(dir, "nc");
+    ret->fNCAnti = *Spectrum::LoadFrom(dir, "nc_anti");
 
     delete dir;
 

--- a/CAFAna/Extrap/TrivialExtrap.h
+++ b/CAFAna/Extrap/TrivialExtrap.h
@@ -61,7 +61,9 @@ namespace ana
     virtual OscillatableSpectrum TauFromMuComponent()     {return fTauFromMu;}
     virtual OscillatableSpectrum AntiTauFromMuComponent() {return fTauFromMuAnti;}
 
+    virtual Spectrum NCTotalComponent() override {return fNCTot;}
     virtual Spectrum NCComponent() {return fNC;}
+    virtual Spectrum NCAntiComponent()  override {return fNCAnti;}
 
     virtual void SaveTo(TDirectory* dir, const std::string& name) const;
     static std::unique_ptr<TrivialExtrap> LoadFrom(TDirectory* dir, const std::string& name);
@@ -80,7 +82,9 @@ namespace ana
         fTauFromEAnti(OscillatableSpectrum::Uninitialized()),
         fTauFromMu    (OscillatableSpectrum::Uninitialized()),
         fTauFromMuAnti(OscillatableSpectrum::Uninitialized()),
-        fNC(Spectrum::Uninitialized())
+        fNCTot(Spectrum::Uninitialized()),
+        fNC(Spectrum::Uninitialized()),
+        fNCAnti(Spectrum::Uninitialized())
     {}
 
     OscillatableSpectrum fNueApp,    fNueAppAnti;
@@ -89,6 +93,7 @@ namespace ana
     OscillatableSpectrum fNueSurv,   fNueSurvAnti;
     OscillatableSpectrum fTauFromE,  fTauFromEAnti;
     OscillatableSpectrum fTauFromMu, fTauFromMuAnti;
-    Spectrum fNC;
+    Spectrum fNCTot;
+    Spectrum fNC, fNCAnti;
   };
 }

--- a/CAFAna/Prediction/IPrediction.cxx
+++ b/CAFAna/Prediction/IPrediction.cxx
@@ -126,6 +126,27 @@ namespace ana
     // Default implementation: no treatment of systematics
     return PredictComponent(calc, flav, curr, sign);
   }
+ 
+  //----------------------------------------------------------------------
+  OscillatableSpectrum IPrediction::ComponentCC(int from, int to) const
+  {
+    std::cout << "WARNING! ComponentCC is unimplemented in IPrediction" << std::endl; abort();
+  }
+
+  Spectrum IPrediction::ComponentNCTotal() const
+  {
+    std::cout << "WARNING! ComponentNCTotal is unimplemented in IPrediction" << std::endl; abort();
+  }
+
+  Spectrum IPrediction::ComponentNC() const
+  {
+    std::cout << "WARNING! ComponentNC is unimplemented in IPrediction" << std::endl; abort();
+  }
+
+  Spectrum IPrediction::ComponentNCAnti() const
+  {
+    std::cout << "WARNING! ComponentNCAnti is unimplemented in IPrediction" << std::endl; abort();
+  }
 
   //----------------------------------------------------------------------
   void IPrediction::SaveTo(TDirectory*, const std::string&) const

--- a/CAFAna/Prediction/IPrediction.h
+++ b/CAFAna/Prediction/IPrediction.h
@@ -89,10 +89,10 @@ namespace ana
                                           Current::Current_t curr,
                                           Sign::Sign_t sign) const;
 
-    virtual OscillatableSpectrum ComponentCC(int from, int to) const
-    {std::cout << "OscillatableSpectrum::ComponentCC() unimplemented" << std::endl; abort();}
-    virtual Spectrum ComponentNC() const
-    {std::cout << "OscillatableSpectrum::ComponentNC() unimplemented" << std::endl; abort();}
+    virtual OscillatableSpectrum ComponentCC(int from, int to) const;
+    virtual Spectrum ComponentNCTotal() const;
+    virtual Spectrum ComponentNC() const;
+    virtual Spectrum ComponentNCAnti() const;
 
     virtual void SaveTo(TDirectory* dir, const std::string& name) const;
   };

--- a/CAFAna/Prediction/PredictionExtrap.cxx
+++ b/CAFAna/Prediction/PredictionExtrap.cxx
@@ -74,8 +74,10 @@ namespace ana
     }
 
     if(curr & Current::kNC){
-      assert(flav == Flavors::kAll && sign == Sign::kBoth); // Don't know how to calculate anything else
-      ret += fExtrap->NCComponent();
+      assert(flav == Flavors::kAll); // Don't know how to calculate anything else
+
+      if(sign & Sign::kNu)     ret += fExtrap->NCComponent();
+      if(sign & Sign::kAntiNu) ret += fExtrap->NCAntiComponent();
     }
 
     return ret;
@@ -127,11 +129,20 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+  // NC components:
+  Spectrum PredictionExtrap::ComponentNCTotal() const 
+  {
+    return fExtrap->NCTotalComponent();
+  }
   Spectrum PredictionExtrap::ComponentNC() const
   {
     return fExtrap->NCComponent();
   }
-
+  Spectrum PredictionExtrap::ComponentNCAnti() const
+  {
+    return fExtrap->NCAntiComponent();
+  }
+  // End NC components.
   //----------------------------------------------------------------------
   void PredictionExtrap::SaveTo(TDirectory* dir, const std::string& name) const
   {

--- a/CAFAna/Prediction/PredictionExtrap.h
+++ b/CAFAna/Prediction/PredictionExtrap.h
@@ -33,7 +33,10 @@ namespace ana
                               Sign::Sign_t sign) const override;
 
     OscillatableSpectrum ComponentCC(int from, int to) const override;
+    // NC components:
+    Spectrum ComponentNCTotal()  const override;
     Spectrum ComponentNC() const override;
+    Spectrum ComponentNCAnti()   const override;
 
     virtual void SaveTo(TDirectory* dir, const std::string& name) const override;
     static std::unique_ptr<PredictionExtrap> LoadFrom(TDirectory* dir, const std::string& name);


### PR DESCRIPTION
Port in nova treatment of NC prediction component. Now distinguish between NC events that come from nu and anti-nu, as well as having a total NC component. This is needed in PredictionInterps when the kSplitBySign flag is set to true.