### PR TITLE
PRISM branch: addressing eDep* rather than eReco* at the FD in detector systematics.

### DIFF
--- a/CAFAna/Systs/RecoEnergyFDSysts.h
+++ b/CAFAna/Systs/RecoEnergyFDSysts.h
@@ -32,7 +32,7 @@ namespace ana
                double& weight) const override {
   
       restore.Add(sr->VisReco_NDFD,
-                  sr->RecoHadE_NDFD,;
+                  sr->RecoHadE_NDFD,
                   sr->RecoLepE_NDFD);
 
       const double scale = 0.02 * sigma;
@@ -67,25 +67,33 @@ namespace ana
                double& weight) const override {
       
       restore.Add(sr->VisReco_NDFD,
+                  sr->RecoHadE_NDFD,
                   sr->RecoLepE_NDFD);
 
       const double scale = 0.01 * sigma;
       if (sr->isFD) {
-        if (sr->isCC && abs(sr->nuPDG) == 14) { // take away muon energy
-          sr->VisReco_NDFD += (sr->VisReco_NDFD - sr->RecoLepE_NDFD) * scale *
-            pow((sr->VisReco_NDFD - sr->RecoLepE_NDFD), 0.5);
+        // To match LBL TDR:
+        // Whether NC or CC, Numu or Nue, we want to shift total "reconstructed neutrino energy"
+        // by the "reconstructed hadronic energy".
+        sr->VisReco_NDFD += (sr->VisReco_NDFD - sr->RecoLepE_NDFD) * scale *
+          pow((sr->VisReco_NDFD - sr->RecoLepE_NDFD), 0.5);
+        // Also shift the hadronic energy variable, if we don't do this then shifted 
+        // plots of the reconstructed hadronic energy will not be different to nominal.
+        sr->RecoHadE_NDFD += sr->RecoHadE_NDFD * scale * pow(sr->RecoHadE_NDFD, 0.5);
+        // If it isn't Numu-CC, also shift the "reconstructed neutrino energy" by the
+        // "reconstructed leptonic energy".
+        // Also shift the reconstructed leptonic energy itself.
+        if (!(sr->isCC && abs(sr->nuPDG) == 14)) {
+          sr->VisReco_NDFD += sr->RecoLepE_NDFD * scale * pow(sr->RecoLepE_NDFD, 0.5);
+          sr->RecoLepE_NDFD += sr->RecoLepE_NDFD * scale * pow(sr->RecoLepE_NDFD, 0.5);
         }
-        else if (sr->isCC && abs(sr->nuPDG) == 12) { // fine to include electron energy
-          sr->VisReco_NDFD += (sr->VisReco_NDFD) * scale *
-            pow((sr->VisReco_NDFD), 0.5);
-        }
-      } 
+      }
     }
   };
 
   extern const RecoEnergySqrtFD kRecoEnergySqrtFD;
 
-  // Total energy scale syst varying with sqrt of the energy
+  // Total energy scale syst varying with inverse sqrt of the energy
   class RecoEnergyInvSqrtFD: public ISyst {
   public:
     RecoEnergyInvSqrtFD() : ISyst("RecoEnergyInvSqrtFD", "Inv Sqrt Total Energy Scale FD Syst") {}
@@ -95,17 +103,25 @@ namespace ana
                double& weight) const override {
 
       restore.Add(sr->VisReco_NDFD,
+                  sr->RecoHadE_NDFD,
                   sr->RecoLepE_NDFD);
 
-      const double scale = 0.02 * sigma;
+      const double scale = 0.01 * sigma;
       if (sr->isFD) {
-        if (sr->isCC && abs(sr->nuPDG) == 14) { // take away muon energy
-          sr->VisReco_NDFD += (sr->VisReco_NDFD - sr->RecoLepE_NDFD) * scale *
-            pow((sr->VisReco_NDFD - sr->RecoLepE_NDFD)+0.1, -0.5);
-        }
-        else if (sr->isCC && abs(sr->nuPDG) == 12) { // fine to include electron energy
-          sr->VisReco_NDFD += (sr->VisReco_NDFD) * scale *
-            pow((sr->VisReco_NDFD+0.1), -0.5);
+        // To match LBL TDR:
+        // Whether NC or CC, Numu or Nue, we want to shift total "reconstructed neutrino energy"
+        // by the "reconstructed hadronic energy".
+        sr->VisReco_NDFD += (sr->VisReco_NDFD - sr->RecoLepE_NDFD) * scale *
+          pow((sr->VisReco_NDFD - sr->RecoLepE_NDFD+0.1), -0.5);
+        // Also shift the hadronic energy variable, if we don't do this then shifted 
+        // plots of the reconstructed hadronic energy will not be different to nominal.
+        sr->RecoHadE_NDFD += sr->RecoHadE_NDFD * scale * pow(sr->RecoHadE_NDFD+0.1, -0.5);
+        // If it isn't Numu-CC, also shift the "reconstructed neutrino energy" by the
+        // "reconstructed leptonic energy".
+        // Also shift the reconstructed leptonic energy itself.
+        if (!(sr->isCC && abs(sr->nuPDG) == 14)) {
+          sr->VisReco_NDFD += sr->RecoLepE_NDFD * scale * pow(sr->RecoLepE_NDFD+0.1, -0.5);
+          sr->RecoLepE_NDFD += sr->RecoLepE_NDFD * scale * pow(sr->RecoLepE_NDFD+0.1, -0.5);
         }
       }
     }

--- a/CAFAna/Systs/RecoEnergyFDSysts.h
+++ b/CAFAna/Systs/RecoEnergyFDSysts.h
@@ -106,7 +106,7 @@ namespace ana
                   sr->RecoHadE_NDFD,
                   sr->RecoLepE_NDFD);
 
-      const double scale = 0.01 * sigma;
+      const double scale = 0.02 * sigma;
       if (sr->isFD) {
         // To match LBL TDR:
         // Whether NC or CC, Numu or Nue, we want to shift total "reconstructed neutrino energy"

--- a/CAFAna/Systs/RecoEnergyFDSysts.h
+++ b/CAFAna/Systs/RecoEnergyFDSysts.h
@@ -119,13 +119,16 @@ namespace ana
                double& weight) const override {
 
       restore.Add(sr->RecoLepE_NDFD,
-                  sr->eRecoPi0,
+                  //sr->eRecoPi0,
+                  sr->eDepPi0,
                   sr->VisReco_NDFD);
 
       const double scale = 0.025 * sigma;
       if (sr->isFD) {
-        sr->eRecoPi0 += sr->eRecoPi0 * scale;
-        sr->VisReco_NDFD += sr->eRecoPi0 * scale;
+        //sr->eRecoPi0 += sr->eRecoPi0 * scale;
+        sr->eDepPi0 += sr->eDepPi0 * scale;
+        //sr->VisReco_NDFD += sr->eRecoPi0 * scale;
+        sr->VisReco_NDFD += sr->eDepPi0 * scale;
         if (sr->isCC && abs(sr->nuPDG) == 12) {
           sr->RecoLepE_NDFD += sr->RecoLepE_NDFD * scale;
           sr->VisReco_NDFD += sr->RecoLepE_NDFD * scale;
@@ -148,13 +151,16 @@ namespace ana
                double& weight) const override {
       
       restore.Add(sr->RecoLepE_NDFD,
-                  sr->eRecoPi0,
+                  //sr->eRecoPi0,
+                  sr->eDepPi0,
                   sr->VisReco_NDFD);
 
       const double scale = 0.025 * sigma;
       if (sr->isFD) {
-        sr->eRecoPi0 += sr->eRecoPi0 * scale * pow(sr->eRecoPi0, 0.5);
-        sr->VisReco_NDFD += sr->eRecoPi0 * scale * pow(sr->eRecoPi0, 0.5); 
+        //sr->eRecoPi0 += sr->eRecoPi0 * scale * pow(sr->eRecoPi0, 0.5);
+        sr->eDepPi0 += sr->eDepPi0 * scale * pow(sr->eDepPi0, 0.5);
+        //sr->VisReco_NDFD += sr->eRecoPi0 * scale * pow(sr->eRecoPi0, 0.5); 
+        sr->VisReco_NDFD += sr->eDepPi0 * scale * pow(sr->eDepPi0, 0.5); 
         if (sr->isCC && abs(sr->nuPDG) == 12) {
           sr->RecoLepE_NDFD += sr->RecoLepE_NDFD * scale * pow(sr->RecoLepE_NDFD, 0.5);
           sr->VisReco_NDFD += sr->RecoLepE_NDFD * scale * pow(sr->RecoLepE_NDFD, 0.5);
@@ -177,13 +183,16 @@ namespace ana
                double& weight) const override {
 
       restore.Add(sr->RecoLepE_NDFD,
-                  sr->eRecoPi0,
+                  //sr->eRecoPi0,
+                  sr->eDepPi0,
                   sr->VisReco_NDFD);
 
       const double scale = 0.025 * sigma;
       if (sr->isFD) {
-        sr->eRecoPi0 += sr->eRecoPi0 * scale * pow(sr->eRecoPi0+0.1, -0.5);
-        sr->VisReco_NDFD += sr->eRecoPi0 * scale * pow(sr->eRecoPi0+0.1, -0.5);
+        //sr->eRecoPi0 += sr->eRecoPi0 * scale * pow(sr->eRecoPi0+0.1, -0.5);
+        sr->eDepPi0 += sr->eDepPi0 * scale * pow(sr->eDepPi0+0.1, -0.5);
+        //sr->VisReco_NDFD += sr->eRecoPi0 * scale * pow(sr->eRecoPi0+0.1, -0.5);
+        sr->VisReco_NDFD += sr->eDepPi0 * scale * pow(sr->eDepPi0+0.1, -0.5);
         if (sr->isCC && abs(sr->nuPDG) == 12) {
           sr->RecoLepE_NDFD += sr->RecoLepE_NDFD * scale * pow(sr->RecoLepE_NDFD+0.1, -0.5);
           sr->VisReco_NDFD += sr->RecoLepE_NDFD * scale * pow(sr->RecoLepE_NDFD+0.1, -0.5);
@@ -208,21 +217,32 @@ namespace ana
                caf::StandardRecord* sr,
                double& weight) const override {
     
-      restore.Add(sr->eRecoPip,
+      /*restore.Add(sr->eRecoPip,
                   sr->eRecoPim,
-                  sr->eRecoP,
+                  sr->eRecoP,*/
+      restore.Add(sr->eDepPip,
+                  sr->eDepPim,
+                  sr->eDepP,
                   sr->VisReco_NDFD);
 
       const double scale = 0.05 * sigma;
       if (sr->isFD) {
-        if (sr->eRecoP < 0) sr->eRecoP = 0.;
+        /*if (sr->eRecoP < 0) sr->eRecoP = 0.;
         if (sr->eRecoPim < 0) sr->eRecoPim = 0.;
         if (sr->eRecoPip < 0) sr->eRecoPip = 0.;
-        const double sumE = sr->eRecoPip + sr->eRecoPim + sr->eRecoP;
+        */
+        if (sr->eDepP < 0) sr->eDepP = 0.;
+        if (sr->eDepPim < 0) sr->eDepPim = 0.;
+        if (sr->eDepPip < 0) sr->eDepPip = 0.;
+        /*const double sumE = sr->eRecoPip + sr->eRecoPim + sr->eRecoP;
         sr->eRecoPip += sr->eRecoPip * scale;
         sr->eRecoPim += sr->eRecoPim * scale;
-        sr->eRecoP += sr->eRecoP * scale;
+        sr->eRecoP += sr->eRecoP * scale;*/
+        const double sumE = sr->eDepPip + sr->eDepPim + sr->eDepP;
         sr->VisReco_NDFD += sumE * scale;
+        sr->eDepPip += sr->eDepPip * scale;
+        sr->eDepPim += sr->eDepPim * scale;
+        sr->eDepP += sr->eDepP * scale;
       }
     }
   };
@@ -240,20 +260,30 @@ namespace ana
                caf::StandardRecord* sr,
                double& weight) const override {
 
-      restore.Add(sr->eRecoPip,
+      /*restore.Add(sr->eRecoPip,
                   sr->eRecoPim,
-                  sr->eRecoP,
+                  sr->eRecoP,*/
+      restore.Add(sr->eDepPip,
+                  sr->eDepPim,
+                  sr->eDepP,
                   sr->VisReco_NDFD);
 
       const double scale = 0.05 * sigma;
       if (sr->isFD) {
-        if (sr->eRecoP < 0) sr->eRecoP = 0.;
+        /*if (sr->eRecoP < 0) sr->eRecoP = 0.;
         if (sr->eRecoPim < 0) sr->eRecoPim = 0.;
-        if (sr->eRecoPip < 0) sr->eRecoPip = 0.;
-        const double sumE = sr->eRecoPip + sr->eRecoPim + sr->eRecoP;
+        if (sr->eRecoPip < 0) sr->eRecoPip = 0.;*/
+        if (sr->eDepP < 0) sr->eDepP = 0.;
+        if (sr->eDepPim < 0) sr->eDepPim = 0.;
+        if (sr->eDepPip < 0) sr->eDepPip = 0.;
+        const double sumE = sr->eDepPip + sr->eDepPim + sr->eDepP;
+        sr->eDepPip += sr->eDepPip * scale * pow(sr->eDepPip, 0.5); // sumE before
+        sr->eDepPim += sr->eDepPim * scale * pow(sr->eDepPim, 0.5); // sumE
+        sr->eDepP += sr->eDepP * scale * pow(sr->eDepP, 0.5); // sumE
+        /*const double sumE = sr->eRecoPip + sr->eRecoPim + sr->eRecoP;
         sr->eRecoPip += sr->eRecoPip * scale * pow(sr->eRecoPip, 0.5); // sumE before
         sr->eRecoPim += sr->eRecoPim * scale * pow(sr->eRecoPim, 0.5); // sumE
-        sr->eRecoP += sr->eRecoP * scale * pow(sr->eRecoP, 0.5); // sumE
+        sr->eRecoP += sr->eRecoP * scale * pow(sr->eRecoP, 0.5); // sumE*/
         sr->VisReco_NDFD += sumE * scale * pow(sumE, 0.5);
       }
     }
@@ -272,20 +302,30 @@ namespace ana
                caf::StandardRecord* sr,
                double& weight) const override {
 
-      restore.Add(sr->eRecoPip,
+      /*restore.Add(sr->eRecoPip,
                   sr->eRecoPim,
-                  sr->eRecoP,
+                  sr->eRecoP,*/
+      restore.Add(sr->eDepPip,
+                  sr->eDepPim,
+                  sr->eDepP,
                   sr->VisReco_NDFD);
 
       const double scale = 0.05 * sigma;
       if (sr->isFD) {
-        if (sr->eRecoP < 0) sr->eRecoP = 0.;
+        /*if (sr->eRecoP < 0) sr->eRecoP = 0.;
         if (sr->eRecoPim < 0) sr->eRecoPim = 0.;
-        if (sr->eRecoPip < 0) sr->eRecoPip = 0.;
-        const double sumE = sr->eRecoPip + sr->eRecoPim + sr->eRecoP;
+        if (sr->eRecoPip < 0) sr->eRecoPip = 0.;*/
+        if (sr->eDepP < 0) sr->eDepP = 0.;
+        if (sr->eDepPim < 0) sr->eDepPim = 0.;
+        if (sr->eDepPip < 0) sr->eDepPip = 0.;
+        /*const double sumE = sr->eRecoPip + sr->eRecoPim + sr->eRecoP;
         sr->eRecoPip += sr->eRecoPip * scale * pow(sr->eRecoPip+0.1, -0.5); // sumE
         sr->eRecoPim += sr->eRecoPim * scale * pow(sr->eRecoPim+0.1, -0.5); // sumE
-        sr->eRecoP += sr->eRecoP * scale * pow(sr->eRecoP+0.1, -0.5); // sumE
+        sr->eRecoP += sr->eRecoP * scale * pow(sr->eRecoP+0.1, -0.5); // sumE*/
+        const double sumE = sr->eDepPip + sr->eDepPim + sr->eDepP;
+        sr->eDepPip += sr->eDepPip * scale * pow(sr->eDepPip+0.1, -0.5); // sumE
+        sr->eDepPim += sr->eDepPim * scale * pow(sr->eDepPim+0.1, -0.5); // sumE
+        sr->eDepP += sr->eDepP * scale * pow(sr->eDepP+0.1, -0.5); // sumE
         sr->VisReco_NDFD += sumE * scale * pow(sumE+0.1, -0.5);
       }
     }
@@ -410,12 +450,15 @@ namespace ana
                caf::StandardRecord* sr, double& weight) const override
     {
       restore.Add(sr->RecoLepE_NDFD,
-                  sr->eRecoPi0,
+                  //sr->eRecoPi0,
+                  sr->eDepPi0,
                   sr->VisReco_NDFD);
       const double scale = .02*sigma;
       if (sr->isFD){
-        sr->VisReco_NDFD  += (sr->ePi0 - sr->eRecoPi0) * scale;
-        sr->eRecoPi0      += (sr->ePi0 - sr->eRecoPi0) * scale;
+        //sr->VisReco_NDFD  += (sr->ePi0 - sr->eRecoPi0) * scale;
+        //sr->eRecoPi0      += (sr->ePi0 - sr->eRecoPi0) * scale;
+        sr->VisReco_NDFD  += (sr->ePi0 - sr->eDepPi0) * scale;
+        sr->eDepPi0       += (sr->ePi0 - sr->eDepPi0) * scale;
         if (sr->isCC && abs(sr->nuPDG)==12) {
           sr->VisReco_NDFD  += (sr->LepE - sr->RecoLepE_NDFD) * scale;
           sr->RecoLepE_NDFD += (sr->LepE - sr->RecoLepE_NDFD) * scale;
@@ -436,19 +479,29 @@ namespace ana
                caf::StandardRecord* sr, double& weight) const override
     {
       restore.Add(sr->VisReco_NDFD,
-                  sr->eRecoP,
+                  /*sr->eRecoP,
                   sr->eRecoPip,
-                  sr->eRecoPim);
+                  sr->eRecoPim);*/
+                  sr->eDepP,
+                  sr->eDepPip,
+                  sr->eDepPim);
       const double scale = .02*sigma;
       if (sr->isFD) {
-        if (sr->eRecoP < 0.) sr->eRecoP = 0.;
+        /*if (sr->eRecoP < 0.) sr->eRecoP = 0.;
         if (sr->eRecoPip < 0.) sr->eRecoPip = 0.;
-        if (sr->eRecoPim < 0.) sr->eRecoPim = 0.;
+        if (sr->eRecoPim < 0.) sr->eRecoPim = 0.;*/
+        if (sr->eDepP < 0.) sr->eDepP = 0.;
+        if (sr->eDepPip < 0.) sr->eDepPip = 0.;
+        if (sr->eDepPim < 0.) sr->eDepPim = 0.;
         const double trueSum = sr->ePip + sr->ePim + sr->eP;
-        const double recoSum = sr->eRecoPip + sr->eRecoPim + sr->eRecoP;
+        /*const double recoSum = sr->eRecoPip + sr->eRecoPim + sr->eRecoP;
         sr->eRecoPip += (sr->ePip - sr->eRecoPip) * scale;
         sr->eRecoPim += (sr->ePim - sr->eRecoPim) * scale;
-        sr->eRecoP   += (sr->eP   - sr->eRecoP)   * scale;
+        sr->eRecoP   += (sr->eP   - sr->eRecoP)   * scale;*/
+        const double recoSum = sr->eDepPip + sr->eDepPim + sr->eDepP;
+        sr->eDepPip += (sr->ePip - sr->eDepPip) * scale;
+        sr->eDepPim += (sr->ePim - sr->eDepPim) * scale;
+        sr->eDepP   += (sr->eP   - sr->eDepP)   * scale;
         sr->VisReco_NDFD += (trueSum - recoSum)   * scale;
       }
     }

--- a/CAFAna/Systs/RecoEnergyFDSysts.h
+++ b/CAFAna/Systs/RecoEnergyFDSysts.h
@@ -32,15 +32,24 @@ namespace ana
                double& weight) const override {
   
       restore.Add(sr->VisReco_NDFD,
+                  sr->RecoHadE_NDFD,;
                   sr->RecoLepE_NDFD);
 
       const double scale = 0.02 * sigma;
       if (sr->isFD) {
-        if (sr->isCC && abs(sr->nuPDG) == 14) { // take away muon energy
-          sr->VisReco_NDFD += (sr->VisReco_NDFD - sr->RecoLepE_NDFD) * scale;
-        }
-        else if (sr->isCC && abs(sr->nuPDG) == 12) { // fine to include electron energy
-          sr->VisReco_NDFD += sr->VisReco_NDFD * scale; 
+        // To match LBL TDR:
+        // Whether NC or CC, Numu or Nue, we want to shift total "reconstructed neutrino energy"
+        // by the "reconstructed hadronic energy".
+        sr->VisReco_NDFD += (sr->VisReco_NDFD - sr->RecoLepE_NDFD) * scale;
+        // Also shift the hadronic energy variable, if we don't do this then shifted 
+        // plots of the reconstructed hadronic energy will not be different to nominal.
+        sr->RecoHadE_NDFD *= 1. + scale;
+        // If it isn't Numu-CC, also shift the "reconstructed neutrino energy" by the
+        // "reconstructed leptonic energy".
+        // Also shift the reconstructed leptonic energy itself.
+        if (!(sr->isCC && abs(sr->nuPDG) == 14)) {
+          sr->VisReco_NDFD += sr->RecoLepE_NDFD * scale; 
+          sr->RecoLepE_NDFD *= 1. + scale;
         }
       }
     }

--- a/CAFAna/Systs/RecoEnergyNDSysts.h
+++ b/CAFAna/Systs/RecoEnergyNDSysts.h
@@ -29,15 +29,24 @@ namespace ana
                double& weight) const override {
   
       restore.Add(sr->VisReco_NDFD,
+                  sr->RecoHadE_NDFD,
                   sr->RecoLepE_NDFD);
 
       const double scale = 0.02 * sigma;
-      if (!sr->isFD) { // in the ND
-        if (sr->isCC && abs(sr->nuPDG) == 14) { // take away muon energy
-          sr->VisReco_NDFD += (sr->VisReco_NDFD - sr->RecoLepE_NDFD) * scale;
-        }
-        else if (sr->isCC && abs(sr->nuPDG) == 12) { // fine to include electron energy
-          sr->VisReco_NDFD += sr->VisReco_NDFD * scale; 
+      if (!sr->isFD) {
+        // To match FD:
+        // Whether NC or CC, Numu or Nue, we want to shift total "reconstructed neutrino energy"
+        // by the "reconstructed hadronic energy".
+        sr->VisReco_NDFD += (sr->VisReco_NDFD - sr->RecoLepE_NDFD) * scale;
+        // Also shift the hadronic energy variable, if we don't do this then shifted 
+        // plots of the reconstructed hadronic energy will not be different to nominal.
+        sr->RecoHadE_NDFD *= 1. + scale;
+        // If it isn't Numu-CC, also shift the "reconstructed neutrino energy" by the
+        // "reconstructed leptonic energy".
+        // Also shift the reconstructed leptonic energy itself.
+        if (!(sr->isCC && abs(sr->nuPDG) == 14)) {
+          sr->VisReco_NDFD += sr->RecoLepE_NDFD * scale; 
+          sr->RecoLepE_NDFD *= 1. + scale;
         }
       }
     }
@@ -55,25 +64,33 @@ namespace ana
                double& weight) const override {
       
       restore.Add(sr->VisReco_NDFD,
+                  sr->RecoHadE_NDFD,
                   sr->RecoLepE_NDFD);
 
       const double scale = 0.01 * sigma;
-      if (!sr->isFD) { // in the ND
-        if (sr->isCC && abs(sr->nuPDG) == 14) { // take away muon energy
-          sr->VisReco_NDFD += (sr->VisReco_NDFD - sr->RecoLepE_NDFD) * scale *
-            pow((sr->VisReco_NDFD - sr->RecoLepE_NDFD), 0.5);
+      if (!sr->isFD) {
+        // To match LBL TDR:
+        // Whether NC or CC, Numu or Nue, we want to shift total "reconstructed neutrino energy"
+        // by the "reconstructed hadronic energy".
+        sr->VisReco_NDFD += (sr->VisReco_NDFD - sr->RecoLepE_NDFD) * scale *
+          pow((sr->VisReco_NDFD - sr->RecoLepE_NDFD), 0.5);
+        // Also shift the hadronic energy variable, if we don't do this then shifted 
+        // plots of the reconstructed hadronic energy will not be different to nominal.
+        sr->RecoHadE_NDFD += sr->RecoHadE_NDFD * scale * pow(sr->RecoHadE_NDFD, 0.5);
+        // If it isn't Numu-CC, also shift the "reconstructed neutrino energy" by the
+        // "reconstructed leptonic energy".
+        // Also shift the reconstructed leptonic energy itself.
+        if (!(sr->isCC && abs(sr->nuPDG) == 14)) {
+          sr->VisReco_NDFD += sr->RecoLepE_NDFD * scale * pow(sr->RecoLepE_NDFD, 0.5);
+          sr->RecoLepE_NDFD += sr->RecoLepE_NDFD * scale * pow(sr->RecoLepE_NDFD, 0.5);
         }
-        else if (sr->isCC && abs(sr->nuPDG) == 12) { // fine to include electron energy
-          sr->VisReco_NDFD += (sr->VisReco_NDFD) * scale *
-            pow((sr->VisReco_NDFD), 0.5);
-        } 
       }
     }
   };
 
   extern const RecoEnergySqrtND kRecoEnergySqrtND;
 
-  // Total energy scale syst varying with sqrt of the energy
+  // Total energy scale syst varying with inverse sqrt of the energy
   class RecoEnergyInvSqrtND: public ISyst {
   public:
     RecoEnergyInvSqrtND() : ISyst("RecoEnergyInvSqrtND", "Inv Sqrt Total Energy Scale ND Syst") {}
@@ -83,17 +100,25 @@ namespace ana
                double& weight) const override {
 
       restore.Add(sr->VisReco_NDFD,
+                  sr->RecoHadE_NDFD,
                   sr->RecoLepE_NDFD);
 
-      const double scale = 0.02 * sigma;
-      if (!sr->isFD) { // in the ND
-        if (sr->isCC && abs(sr->nuPDG) == 14) { // take away muon energy
-          sr->VisReco_NDFD += (sr->VisReco_NDFD - sr->RecoLepE_NDFD) * scale *
-            pow((sr->VisReco_NDFD - sr->RecoLepE_NDFD) + 0.1, -0.5);
-        }
-        else if (sr->isCC && abs(sr->nuPDG) == 12) { // fine to include electron energy
-          sr->VisReco_NDFD += (sr->VisReco_NDFD) * scale *
-            pow((sr->VisReco_NDFD + 0.1), -0.5);
+      const double scale = 0.01 * sigma;
+      if (!sr->isFD) {
+        // To match LBL TDR:
+        // Whether NC or CC, Numu or Nue, we want to shift total "reconstructed neutrino energy"
+        // by the "reconstructed hadronic energy".
+        sr->VisReco_NDFD += (sr->VisReco_NDFD - sr->RecoLepE_NDFD) * scale *
+          pow((sr->VisReco_NDFD - sr->RecoLepE_NDFD+0.1), -0.5);
+        // Also shift the hadronic energy variable, if we don't do this then shifted 
+        // plots of the reconstructed hadronic energy will not be different to nominal.
+        sr->RecoHadE_NDFD += sr->RecoHadE_NDFD * scale * pow(sr->RecoHadE_NDFD+0.1, -0.5);
+        // If it isn't Numu-CC, also shift the "reconstructed neutrino energy" by the
+        // "reconstructed leptonic energy".
+        // Also shift the reconstructed leptonic energy itself.
+        if (!(sr->isCC && abs(sr->nuPDG) == 14)) {
+          sr->VisReco_NDFD += sr->RecoLepE_NDFD * scale * pow(sr->RecoLepE_NDFD+0.1, -0.5);
+          sr->RecoLepE_NDFD += sr->RecoLepE_NDFD * scale * pow(sr->RecoLepE_NDFD+0.1, -0.5);
         }
       }
     }

--- a/CAFAna/Systs/RecoEnergyNDSysts.h
+++ b/CAFAna/Systs/RecoEnergyNDSysts.h
@@ -103,7 +103,7 @@ namespace ana
                   sr->RecoHadE_NDFD,
                   sr->RecoLepE_NDFD);
 
-      const double scale = 0.01 * sigma;
+      const double scale = 0.02 * sigma;
       if (!sr->isFD) {
         // To match LBL TDR:
         // Whether NC or CC, Numu or Nue, we want to shift total "reconstructed neutrino energy"


### PR DESCRIPTION
Resolves #19. Also changing our implementation of global detector energy scale systematics, we weren't previously shifting NC events at all. Tried to pull all of these systematics in line with what is done in the LBL TDR.