### PR TITLE
feature/loadfromregistry

### DIFF
--- a/CAFAna/Experiment/CountingExperiment.cxx
+++ b/CAFAna/Experiment/CountingExperiment.cxx
@@ -3,6 +3,7 @@
 #include "CAFAna/Prediction/IPrediction.h"
 
 #include "CAFAna/Core/LoadFromFile.h"
+#include "CAFAna/Core/LoadFromRegistry.h"
 #include "CAFAna/Core/Utilities.h"
 
 #include "OscLib/IOscCalc.h"
@@ -13,6 +14,8 @@
 
 namespace ana
 {
+  REGISTER_LOADFROM("CountingExperiment", IExperiment, CountingExperiment);
+
   //----------------------------------------------------------------------
   CountingExperiment::CountingExperiment(const IPrediction* p,
                                          const Spectrum& d)

--- a/CAFAna/Experiment/IExperiment.cxx
+++ b/CAFAna/Experiment/IExperiment.cxx
@@ -1,6 +1,7 @@
 #include "CAFAna/Experiment/IExperiment.h"
 
 #include "CAFAna/Core/LoadFromFile.h"
+#include "CAFAna/Core/LoadFromRegistry.h"
 #include "CAFAna/Core/Utilities.h"
 
 #include "TFile.h"
@@ -8,13 +9,6 @@
 
 #include <cassert>
 #include <iostream>
-
-// To implement LoadFrom()
-#include "CAFAna/Experiment/CountingExperiment.h"
-#include "CAFAna/Experiment/SingleSampleExperiment.h"
-#include "CAFAna/Experiment/SolarConstraints.h"
-#include "CAFAna/Experiment/MultiExperiment.h"
-#include "CAFAna/Experiment/ReactorExperiment.h"
 
 namespace ana
 {
@@ -28,11 +22,8 @@ namespace ana
     const TString tag = ptag->GetString();
     delete ptag;
 
-    if(tag == "CountingExperiment") return CountingExperiment::LoadFrom(dir, name);
-    if(tag == "ReactorExperiment") return ReactorExperiment::LoadFrom(dir, name);
-    if(tag == "SingleSampleExperiment") return SingleSampleExperiment::LoadFrom(dir, name);
-    if(tag == "SolarConstraints") return SolarConstraints::LoadFrom(dir, name);
-    if(tag == "MultiExperiment") return MultiExperiment::LoadFrom(dir, name);
+    const auto func = LoadFromRegistry<IExperiment>::Get(tag.Data());
+    if(func) return func(dir, name);
 
     std::cerr << "Unknown Experiment type '" << tag << "'" << std::endl;
     abort();

--- a/CAFAna/Experiment/MultiExperiment.cxx
+++ b/CAFAna/Experiment/MultiExperiment.cxx
@@ -3,6 +3,7 @@
 #include "CAFAna/Core/Utilities.h"
 
 #include "CAFAna/Core/LoadFromFile.h"
+#include "CAFAna/Core/LoadFromRegistry.h"
 #include "CAFAna/Core/Stan.h"
 
 #include "OscLib/IOscCalc.h"
@@ -16,6 +17,8 @@
 
 namespace ana
 {
+  REGISTER_LOADFROM("MultiExperiment", IExperiment, MultiExperiment);
+
   //----------------------------------------------------------------------
   SystShifts MultiExperiment::TranslateShifts(const SystShifts& syst, int idx) const
   {

--- a/CAFAna/Experiment/ReactorExperiment.cxx
+++ b/CAFAna/Experiment/ReactorExperiment.cxx
@@ -2,6 +2,7 @@
 
 #include "CAFAna/Vars/FitVars.h"
 
+#include "CAFAna/Core/LoadFromRegistry.h"
 #include "CAFAna/Core/MathUtil.h"
 
 #include "TDirectory.h"
@@ -12,6 +13,8 @@
 
 namespace ana
 {
+  REGISTER_LOADFROM("ReactorExperiment", IExperiment, ReactorExperiment);
+
   //----------------------------------------------------------------------
   double ReactorExperiment::ChiSq(osc::IOscCalcAdjustable* osc,
                                   const SystShifts& /*syst*/) const

--- a/CAFAna/Experiment/SingleSampleExperiment.cxx
+++ b/CAFAna/Experiment/SingleSampleExperiment.cxx
@@ -1,6 +1,7 @@
 #include "CAFAna/Experiment/SingleSampleExperiment.h"
 
 #include "CAFAna/Core/LoadFromFile.h"
+#include "CAFAna/Core/LoadFromRegistry.h"
 #include "CAFAna/Core/Stan.h"
 #include "CAFAna/Core/StanUtils.h"
 #include "CAFAna/Core/Utilities.h"
@@ -13,6 +14,8 @@
 
 namespace ana
 {
+  REGISTER_LOADFROM("SingleSampleExperiment", IExperiment, SingleSampleExperiment);
+
   //----------------------------------------------------------------------
   SingleSampleExperiment::SingleSampleExperiment(const IPrediction* pred,
                                                  const Spectrum& data)

--- a/CAFAna/Experiment/SolarConstraints.cxx
+++ b/CAFAna/Experiment/SolarConstraints.cxx
@@ -1,6 +1,8 @@
 #include "CAFAna/Experiment/SolarConstraints.h"
 
 #include "OscLib/IOscCalc.h"
+
+#include "CAFAna/Core/LoadFromRegistry.h"
 #include "CAFAna/Core/MathUtil.h"
 
 #include "TDirectory.h"
@@ -12,6 +14,8 @@
 
 namespace ana
 {
+  REGISTER_LOADFROM("SolarConstraints", IExperiment, SolarConstraints);
+
   //----------------------------------------------------------------------
   SolarConstraints::SolarConstraints()
   {

--- a/CAFAna/Extrap/IExtrap.cxx
+++ b/CAFAna/Extrap/IExtrap.cxx
@@ -1,14 +1,12 @@
 #include "CAFAna/Extrap/IExtrap.h"
 
 #include "CAFAna/Core/LoadFromFile.h"
+#include "CAFAna/Core/LoadFromRegistry.h"
 
 #include "TDirectory.h"
 #include "TObjString.h"
 
 #include <iostream>
-
-// To implement LoadFrom()
-#include "CAFAna/Extrap/TrivialExtrap.h"
 
 namespace ana
 {
@@ -20,8 +18,10 @@ namespace ana
     assert(ptag);
 
     const TString tag = ptag->GetString();
+    delete ptag;
 
-    if(tag == "TrivialExtrap") return TrivialExtrap::LoadFrom(dir, name);
+    const auto func = LoadFromRegistry<IExtrap>::Get(tag.Data());
+    if(func) return func(dir, name);
 
     std::cerr << "Unknown Extrap type '" << tag << "'" << std::endl;
     abort();

--- a/CAFAna/Extrap/TrivialExtrap.cxx
+++ b/CAFAna/Extrap/TrivialExtrap.cxx
@@ -1,5 +1,7 @@
 #include "CAFAna/Extrap/TrivialExtrap.h"
 
+#include "CAFAna/Core/LoadFromRegistry.h"
+
 #include "CAFAna/Cuts/TruthCuts.h"
 #include "CAFAna/Core/Loaders.h"
 #include "CAFAna/Core/SpectrumLoader.h"
@@ -9,6 +11,8 @@
 
 namespace ana
 {
+  REGISTER_LOADFROM("TrivialExtrap", IExtrap, TrivialExtrap);
+
   //----------------------------------------------------------------------
   TrivialExtrap::TrivialExtrap(SpectrumLoaderBase& loaderNonswap,
                                SpectrumLoaderBase& loaderNue,

--- a/CAFAna/Prediction/IPrediction.cxx
+++ b/CAFAna/Prediction/IPrediction.cxx
@@ -1,6 +1,7 @@
 #include "CAFAna/Prediction/IPrediction.h"
 
 #include "CAFAna/Core/LoadFromFile.h"
+#include "CAFAna/Core/LoadFromRegistry.h"
 
 #include "OscLib/IOscCalc.h"
 
@@ -9,13 +10,6 @@
 
 #include "TDirectory.h"
 #include "TObjString.h"
-
-// To implement LoadFrom()
-#include "CAFAna/Prediction/PredictionNoExtrap.h"
-#include "CAFAna/Prediction/PredictionInterp.h"
-#include "CAFAna/Prediction/PredictionNoOsc.h"
-#include "CAFAna/Prediction/PredictionScaleComp.h"
-#include "CAFAna/Prediction/PredictionNuOnE.h"
 
 namespace ana
 {
@@ -28,17 +22,8 @@ namespace ana
     const TString tag = ptag->GetString();
     delete ptag;
 
-    if(tag == "PredictionNoExtrap") return PredictionNoExtrap::LoadFrom(dir, name);
-
-    // Backwards compatibility
-    if(tag == "PredictionInterp" ||
-       tag == "PredictionInterp2") return PredictionInterp::LoadFrom(dir, name);
-
-    if(tag == "PredictionNoOsc") return PredictionNoOsc::LoadFrom(dir, name);
-
-    if(tag == "PredictionScaleComp") return PredictionScaleComp::LoadFrom(dir, name);
-
-    if(tag == "PredictionNuOnE") return PredictionNuOnE::LoadFrom(dir, name);
+    const auto func = LoadFromRegistry<IPrediction>::Get(tag.Data());
+    if(func) return func(dir, name);
 
     std::cerr << "Unknown Prediction type '" << tag << "'" << std::endl;
     abort();
@@ -126,7 +111,7 @@ namespace ana
     // Default implementation: no treatment of systematics
     return PredictComponent(calc, flav, curr, sign);
   }
- 
+
   //----------------------------------------------------------------------
   OscillatableSpectrum IPrediction::ComponentCC(int from, int to) const
   {

--- a/CAFAna/Prediction/PredictionInterp.cxx
+++ b/CAFAna/Prediction/PredictionInterp.cxx
@@ -2,6 +2,7 @@
 
 #include "CAFAna/Core/ISyst.h"
 #include "CAFAna/Core/LoadFromFile.h"
+#include "CAFAna/Core/LoadFromRegistry.h"
 #include "CAFAna/Core/MathUtil.h"
 #include "CAFAna/Core/Ratio.h"
 #include "CAFAna/Core/Registry.h"
@@ -32,6 +33,8 @@
 
 namespace ana
 {
+  REGISTER_LOADFROM("PredictionInterp", IPrediction, PredictionInterp);
+
   //----------------------------------------------------------------------
   PredictionInterp::PredictionInterp(std::vector<const ISyst*> systs,
                                      osc::IOscCalc* osc,

--- a/CAFAna/Prediction/PredictionNoExtrap.cxx
+++ b/CAFAna/Prediction/PredictionNoExtrap.cxx
@@ -2,6 +2,7 @@
 
 #include "CAFAna/Extrap/IExtrap.h"
 #include "CAFAna/Core/LoadFromFile.h"
+#include "CAFAna/Core/LoadFromRegistry.h"
 
 #include "CAFAna/Core/Loaders.h"
 #include "CAFAna/Extrap/TrivialExtrap.h"
@@ -12,6 +13,8 @@
 
 namespace ana
 {
+  REGISTER_LOADFROM("PredictionNoExtrap", IPrediction, PredictionNoExtrap);
+
   //----------------------------------------------------------------------
   PredictionNoExtrap::PredictionNoExtrap(SpectrumLoaderBase& loaderNonswap,
                                          SpectrumLoaderBase& loaderNue,

--- a/CAFAna/Prediction/PredictionNoOsc.cxx
+++ b/CAFAna/Prediction/PredictionNoOsc.cxx
@@ -2,6 +2,7 @@
 
 #include "CAFAna/Extrap/IExtrap.h"
 #include "CAFAna/Core/LoadFromFile.h"
+#include "CAFAna/Core/LoadFromRegistry.h"
 
 #include "CAFAna/Core/Loaders.h"
 #include "CAFAna/Extrap/TrivialExtrap.h"
@@ -14,6 +15,8 @@
 
 namespace ana
 {
+  REGISTER_LOADFROM("PredictionNoOsc", IPrediction, PredictionNoOsc);
+
   //----------------------------------------------------------------------
   PredictionNoOsc::PredictionNoOsc(SpectrumLoaderBase& loader,
                                    const std::string& label,

--- a/CAFAna/Prediction/PredictionNuOnE.cxx
+++ b/CAFAna/Prediction/PredictionNuOnE.cxx
@@ -1,5 +1,7 @@
 #include "CAFAna/Prediction/PredictionNuOnE.h"
 
+#include "CAFAna/Core/LoadFromRegistry.h"
+
 #include "CAFAna/Cuts/TruthCuts.h"
 
 #include "StandardRecord/SRProxy.h"
@@ -9,6 +11,8 @@
 
 namespace ana
 {
+  REGISTER_LOADFROM("PredictionNuOnE", IPrediction, PredictionNuOnE);
+
   // Simple counting experiment
   const HistAxis kNuOnEaxis("Dummy nu-on-e axis", Binning::Simple(1, 0, 2), Constant(1));
 

--- a/CAFAna/Prediction/PredictionScaleComp.cxx
+++ b/CAFAna/Prediction/PredictionScaleComp.cxx
@@ -2,6 +2,7 @@
 
 #include "CAFAna/Core/Cut.h"
 #include "CAFAna/Core/LoadFromFile.h"
+#include "CAFAna/Core/LoadFromRegistry.h"
 #include "CAFAna/Prediction/PredictionNoOsc.h"
 #include "CAFAna/Prediction/PredictionNoExtrap.h"
 
@@ -14,6 +15,8 @@
 
 namespace ana
 {
+  REGISTER_LOADFROM("PredictionScaleComp", IPrediction, PredictionScaleComp);
+
   //----------------------------------------------------------------------
   PredictionScaleComp::
   PredictionScaleComp(SpectrumLoaderBase& loader,


### PR DESCRIPTION
Use LoadFromRegistry system so that class names don't have to be hardcoded in the core code (and various predictions etc can thus be defined in subsidiary packages).