### PR TITLE
Temporarily bypass Stan to get `main` building

### DIFF
--- a/CAFAna/CMakeLists.txt
+++ b/CAFAna/CMakeLists.txt
@@ -6,6 +6,11 @@ find_program(CMAKE_CXX_COMPILER NAMES $ENV{CXX} g++ PATHS ENV PATH NO_DEFAULT_PA
 
 project(CAFAna VERSION 2.00.00)
 
+set(CAFANA_USE_STAN False CACHE BOOL "Build against Stan?")
+if(CAFANA_USE_STAN)
+  add_compile_options(-DCAFANA_USE_STAN)
+endif()
+
 #Changes default install path to be a subdirectory of the build dir.
 #Can set build dir at configure time with -DCMAKE_INSTALL_PREFIX=/install/path
 if(NOT DEFINED CMAKE_INSTALL_PREFIX OR 
@@ -52,14 +57,18 @@ include_directories(
   ${CMAKE_BINARY_DIR}/Ext
   ${BOOST_INC}
   ${EIGEN_INC}
-  ${SUNDIALS_INC}
-  ${STAN_MATH_INC}
-  ${STAN_INC}
   ${TBB_INC}
   $ENV{OSCLIB_INC}
   $ENV{CAFANACORE_INC}
   $ENV{DUNEANAOBJ_INC}
 )
+if(CAFANA_USE_STAN)
+  include_directories(
+          ${SUNDIALS_INC}
+          ${STAN_MATH_INC}
+          ${STAN_INC}
+  )
+endif()
 
 find_library(CAFANACOREEXT CAFAnaCoreExt $ENV{CAFANACORE_LIB})
 find_library(STANDARDRECORD duneanaobj_StandardRecord $ENV{DUNEANAOBJ_LIB})

--- a/CAFAna/CMakeLists.txt
+++ b/CAFAna/CMakeLists.txt
@@ -6,9 +6,9 @@ find_program(CMAKE_CXX_COMPILER NAMES $ENV{CXX} g++ PATHS ENV PATH NO_DEFAULT_PA
 
 project(CAFAna VERSION 2.00.00)
 
-set(CAFANA_USE_STAN False CACHE BOOL "Build against Stan?")
+option(CAFANA_USE_STAN "Build against Stan?" False)
 if(CAFANA_USE_STAN)
-  add_compile_options(-DCAFANA_USE_STAN)
+  add_compile_options(CAFANA_USE_STAN)
 endif()
 
 #Changes default install path to be a subdirectory of the build dir.

--- a/CAFAna/Core/Binning.cxx
+++ b/CAFAna/Core/Binning.cxx
@@ -1,7 +1,5 @@
 #include "CAFAna/Core/Binning.h"
 
-#include <cassert>
-
 #include "TDirectory.h"
 #include "TH1.h"
 #include "TObjString.h"

--- a/CAFAna/Core/CMakeLists.txt
+++ b/CAFAna/Core/CMakeLists.txt
@@ -22,11 +22,15 @@ set(Core_implementation_files
   Utilities.cxx
   Var.cxx
   )
+if(CAFANA_USE_STAN)
+  set(Core_implementation_files ${Core_implementation_files}
+
+  )
+endif()
 
 set(Core_header_files
   Binning.h
   Cut.h
-  FitVarWithPrior.h
   HistAxis.h
   IFitVar.h
   IRecordSink.h
@@ -48,7 +52,6 @@ set(Core_header_files
   Sources.ixx
   SpectrumLoader.h
   SpectrumLoaderBase.h
-  StanTypedefs.h
   StanUtils.h
   SystShifts.h
   TruthMatching.h
@@ -56,8 +59,14 @@ set(Core_header_files
   Var.h
   Weight.h
   ModeConversionUtilities.h
-  rootlogon.C)
-
+  rootlogon.C
+)
+if(CAFANA_USE_STAN)
+  set(Core_header_files ${Core_header_files}
+      StanTypedefs.h
+      FitVarWithPrior.h
+  )
+endif()
 add_library(CAFAnaCore SHARED ${Core_implementation_files})
 target_link_libraries(CAFAnaCore
   ${STANDARDRECORDPROXY}

--- a/CAFAna/Core/CMakeLists.txt
+++ b/CAFAna/Core/CMakeLists.txt
@@ -73,8 +73,14 @@ target_link_libraries(CAFAnaCore
   CAFAnaCore::Ext 
   OscLib::All
   ROOT::ROOT 
-  Stan::All 
   Boost::filesystem)
+if(CAFANA_USE_STAN)
+  target_link_libraries(CAFAnaCore Stan::All)
+else()
+  # normally Stan would also drag in Eigen, but we can't count on that if we're not using Stan
+  target_link_libraries(CAFAnaCore Eigen3::Eigen)
+endif()
+
 
 set_target_properties(CAFAnaCore PROPERTIES
   PUBLIC_HEADER "${Core_header_files}")

--- a/CAFAna/Core/EnsembleSpectrum.cxx
+++ b/CAFAna/Core/EnsembleSpectrum.cxx
@@ -169,8 +169,12 @@ namespace ana
   {
     const int nbins = fAxis.GetBins1D().NBins()+2;
     if(fHist.HasStan()){
+#ifdef CAFANA_USE_STAN
       return Spectrum(Eigen::ArrayXstan(fHist.GetEigenStan().segment(nbins*univIdx, nbins)),
                       fAxis, fPOT, fLivetime);
+#else
+      throw std::runtime_error("EnsembleSpectrum::Universe(): attempt to use Stan-aware EnsembleSpectrum, but Stan support was not enabled in lblpwgtools.  Abort");
+#endif
     }
     else{
       return Spectrum(Eigen::ArrayXd(fHist.GetEigen().segment(nbins*univIdx, nbins)),

--- a/CAFAna/Core/IFitVar.cxx
+++ b/CAFAna/Core/IFitVar.cxx
@@ -1,7 +1,11 @@
 #include "CAFAna/Core/IFitVar.h"
 
 #include "CAFAna/Core/MathUtil.h"
+
+#ifdef CAFANA_USE_STAN
 #include "CAFAna/Core/Stan.h"
+#endif
+#include "CAFAna/Core/StanUtils.h"
 
 #include <cmath>
 
@@ -29,6 +33,9 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+
+#ifdef CAFANA_USE_STAN
   stan::math::var StanExp(const stan::math::var& x){return exp(x);}
   stan::math::var StanLog(const stan::math::var& x){return log(x);}
+#endif
 } // namespace

--- a/CAFAna/Core/IFitVar.h
+++ b/CAFAna/Core/IFitVar.h
@@ -4,8 +4,11 @@
 #include "CAFAna/Core/OscCalcFwdDeclare.h"
 #include "CAFAna/Core/Registry.h"
 #include "CAFAna/Core/StanTypedefs.h"
-#include "CAFAna/Core/StanVar.h"
 
+
+#ifdef CAFANA_USE_STAN
+#include "CAFAna/Core/StanVar.h"
+#endif
 #include "CAFAna/Core/StanUtils.h"
 
 namespace ana
@@ -51,6 +54,7 @@ namespace ana
       }
   };
 
+#ifdef CAFANA_USE_STAN
   // We want the callers of these to be inlined below so the class can work
   // templated over any type, but we need the implementation in the .cxx so we
   // don't have to include the full Stan.h here. This is ugly :(
@@ -88,4 +92,11 @@ namespace ana
       /// but this can be overridden if there optimizations that speed up the calculation.
       virtual stan::math::var LogPrior(const stan::math::var& var, const osc::IOscCalcAdjustableStan* calc) const {return StanLog(Prior(var, calc));}
   };
+#else
+  template <typename VarClass>
+  class StanFitSupport : public VarClass
+  {
+    using VarClass::VarClass;
+  };
+#endif
 } // namespace

--- a/CAFAna/Core/OscCurve.cxx
+++ b/CAFAna/Core/OscCurve.cxx
@@ -42,6 +42,7 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+#ifdef CAFANA_USE_STAN
   OscCurve::OscCurve(osc::IOscCalcStan* calc, int from, int to)
     : Ratio(Hist::AdoptStan(ToEigen(calc, from, to)),
             std::vector<Binning>(1, kTrueEnergyBins),
@@ -49,6 +50,7 @@ namespace ana
       fFrom(from), fTo(to)
   {
   }
+#endif
 
   //----------------------------------------------------------------------
   OscCurve::~OscCurve()

--- a/CAFAna/Core/OscCurve.h
+++ b/CAFAna/Core/OscCurve.h
@@ -12,7 +12,9 @@ namespace ana
   {
   public:
     OscCurve(osc::IOscCalc* calc, int from, int to);
+#ifdef CAFANA_USE_STAN
     OscCurve(osc::IOscCalcStan* calc, int from, int to);
+#endif
     virtual ~OscCurve();
 
     OscCurve(const OscCurve& rhs) = default;

--- a/CAFAna/Core/OscillatableSpectrum.cxx
+++ b/CAFAna/Core/OscillatableSpectrum.cxx
@@ -3,8 +3,12 @@
 #include "CAFAna/Core/Binning.h"
 #include "CAFAna/Core/OscCurve.h"
 #include "CAFAna/Core/Ratio.h"
-#include "CAFAna/Core/Stan.h"
 #include "CAFAna/Core/Utilities.h"
+
+#ifdef CAFANA_USE_STAN
+#include "CAFAna/Core/Stan.h"
+#endif
+
 
 #include "duneanaobj/StandardRecord/Proxy/SRProxy.h"
 #include "duneanaobj/StandardRecord/SRInteraction.h"
@@ -153,11 +157,13 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+#ifdef CAFANA_USE_STAN
   Spectrum OscillatableSpectrum::Oscillated(osc::IOscCalcStan* calc,
                                             int from, int to) const
   {
     return _Oscillated(calc, from, to);
   }
+#endif
 
   //----------------------------------------------------------------------
   OscillatableSpectrum& OscillatableSpectrum::operator+=(const OscillatableSpectrum& rhs)

--- a/CAFAna/Core/OscillatableSpectrum.h
+++ b/CAFAna/Core/OscillatableSpectrum.h
@@ -76,7 +76,9 @@ namespace ana
     Spectrum TrueEnergy() const {return WeightingVariable();}
 
     Spectrum Oscillated(osc::IOscCalc* calc, int from, int to) const;
+#ifdef CAFANA_USE_STAN
     Spectrum Oscillated(osc::IOscCalcStan* calc, int from, int to) const;
+#endif
 
     OscillatableSpectrum& operator+=(const OscillatableSpectrum& rhs);
     OscillatableSpectrum operator+(const OscillatableSpectrum& rhs) const;

--- a/CAFAna/Core/StanTypedefs.h
+++ b/CAFAna/Core/StanTypedefs.h
@@ -6,6 +6,8 @@
 ///    and it's much easier to maintain if it's in a single place.
 #pragma once
 
+#ifdef CAFANA_USE_STAN
+
 #include "stan/math/rev/core/var_value_fwd_declare.hpp"
 
 namespace stan
@@ -54,3 +56,5 @@ namespace ana
 
 
 }
+
+#endif

--- a/CAFAna/Core/StanUtils.cxx
+++ b/CAFAna/Core/StanUtils.cxx
@@ -1,11 +1,18 @@
 #include "CAFAna/Core/StanUtils.h"
 
+#include <iostream>
+
+#ifdef CAFANA_USE_STAN
 #include "CAFAna/Core/Stan.h"
+#endif
+
 #include "CAFAna/Core/Utilities.h"
 
 namespace ana
 {
   //----------------------------------------------------------------------
+
+#ifdef CAFANA_USE_STAN
   stan::math::var LogLikelihood(const Eigen::ArrayXstan& exp,
                                 const Eigen::ArrayXd& obs)
   {
@@ -20,4 +27,13 @@ namespace ana
 
     return chi;
   }
+#endif
+
+  void NoStanError()
+  {
+    const auto err = "PredictionInterp::ShiftSpectrum(): Attempt to use Stan-aware Spectrum or Syst without Stan support built into CAFAna!  Abort.";
+    std::cerr << err << "\n";
+    throw std::runtime_error(err);
+  }
+
 }

--- a/CAFAna/Core/StanUtils.h
+++ b/CAFAna/Core/StanUtils.h
@@ -1,12 +1,16 @@
 #pragma once
 
+#ifdef CAFANA_USE_STAN
 #include "CAFAna/Core/StanVar.h"
+#endif
 
 #include <Eigen/Dense>
 
+#ifdef CAFANA_USE_STAN
 namespace Eigen{
   using ArrayXstan = Eigen::Array<stan::math::var, Eigen::Dynamic, 1>;
 }
+#endif
 
 namespace util
 {
@@ -14,6 +18,7 @@ namespace util
   // always get the value in functions
   // that are templated over both double and stan::math::var.
 
+#ifdef CAFANA_USE_STAN
   /// Either no-op or convert stan::math::var to double.
   /// Exists so GetVal<T>(var) can be used with one signature inside a function templated over both stan::math::var & double.
   /// (see, e.g., CAFAna/Fit/StanFitter.cxx.)
@@ -27,6 +32,7 @@ namespace util
   /// explicit specialization for stan::math::var return value
   template <>
   inline stan::math::var GetValAs(const stan::math::var &val) { return val; }
+#endif
 
   /// Companion to GetValAs<>(stan::math::var) to provide ability to use GetValAs<double>(double)
   /// without implicitly converting to a stan::math::var.
@@ -34,18 +40,23 @@ namespace util
   template <typename T>
   inline typename std::enable_if<std::is_convertible<T, double>::value, T>::type GetValAs(double val)  { return val; }
 
+#ifdef CAFANA_USE_STAN
   /// Replacement for operator=() making it clear that you're 'casting' across double-stan::math::var boundary
   inline void SetVal(double& target, const stan::math::var& source) {target = source.val();}
   inline void SetVal(stan::math::var& target, const double& source) {target = source;}
   inline void SetVal(stan::math::var& target, const stan::math::var& source) {target = source;}
+#endif
 
   inline void SetVal(double& target, const double& source) {target = source;}
+
+  void NoStanError();
 }
 
 namespace ana
 {
+#ifdef CAFANA_USE_STAN
   /// Variant that handles the prediction in the form of Stan vars
   stan::math::var LogLikelihood(const Eigen::ArrayXstan& exp,
                                 const Eigen::ArrayXd& obs);
-
+#endif
 }

--- a/CAFAna/Core/SystShifts.cxx
+++ b/CAFAna/Core/SystShifts.cxx
@@ -38,6 +38,7 @@ namespace ana
       fSystsDbl.emplace(syst, Clamp(shift, syst));
   }
   //----------------------------------------------------------------------
+#ifdef CAFANA_USE_STAN
   SystShifts::SystShifts(const ISyst* syst, stan::math::var shift)
       : fID(fgNextID++)
   {
@@ -46,6 +47,7 @@ namespace ana
     // so that when the Stan cache gets invalidated we can still return something usable.
     fSystsDbl.emplace(syst, Clamp(util::GetValAs<double>(shift), syst));
   }
+#endif
   //----------------------------------------------------------------------
   SystShifts::SystShifts(const std::map<const ISyst *, double> &shifts)
       : fID(fgNextID++) {
@@ -63,6 +65,7 @@ namespace ana
       //fSystsDbl.emplace(it.first, it.second);
   }
   //----------------------------------------------------------------------
+#ifdef CAFANA_USE_STAN
   SystShifts::SystShifts(const std::map<const ISyst*, stan::math::var>& shifts)
       : fID(fgNextID++)
   {
@@ -72,6 +75,7 @@ namespace ana
       fSystsDbl.emplace(it.first, util::GetValAs<double>(it.second));
     }
   }
+#endif
   //----------------------------------------------------------------------
   SystShifts SystShifts::RandomThrow(const std::vector<const ISyst*>& systs)
   {
@@ -90,6 +94,7 @@ namespace ana
   {
     fID = fgNextID++;
 
+#ifdef CAFANA_USE_STAN
     // if this slot already exists in the Stan systs, and we're not setting the same value,
     // some shenanigans are going on that we need to figure out.  abort.
     auto itStan = fSystsStan.find(syst);
@@ -101,12 +106,14 @@ namespace ana
       std::cerr << "Abort." << std::endl;
       abort();
     }
+#endif
 
     fSystsDbl.erase(syst);
     if(force || shift != 0.) fSystsDbl.emplace(syst, Clamp(shift, syst));
   }
 
   //----------------------------------------------------------------------
+#ifdef CAFANA_USE_STAN
   void SystShifts::SetShift(const ISyst* syst, stan::math::var shift)
   {
     fSystsStan.erase(syst);
@@ -115,7 +122,7 @@ namespace ana
     fSystsStan.emplace(syst, shift);
     SetShift(syst, util::GetValAs<double>(shift), true);
   }
-
+#endif
   //----------------------------------------------------------------------
   template <>
   double SystShifts::GetShift(const ISyst* syst) const
@@ -127,6 +134,7 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+#ifdef CAFANA_USE_STAN
   template <>
   stan::math::var SystShifts::GetShift(const ISyst* syst) const
   {
@@ -147,14 +155,16 @@ namespace ana
     }
     return (it == fSystsStan.end()) ? 0 : it->second;
   }
-
+#endif
   //----------------------------------------------------------------------
   void SystShifts::ResetToNominal()
   {
     fID = 0;
 
     fSystsDbl.clear();
+#ifdef CAFANA_USE_STAN
     fSystsStan.clear();
+#endif
   }
 
   //----------------------------------------------------------------------
@@ -167,7 +177,9 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+#ifdef CAFANA_USE_STAN
   stan::math::var SystShifts::LogPrior() const { return log(Prior()); }
+#endif
 
   //----------------------------------------------------------------------
   void SystShifts::Shift(caf::SRInteractionProxy* sr,
@@ -242,7 +254,9 @@ namespace ana
 
   // manually instantiate the template for the correct types
   template double SystShifts::Clamp<double>(const double&, const ISyst*);
+#ifdef CAFANA_USE_STAN
   template stan::math::var SystShifts::Clamp<stan::math::var>(const stan::math::var&, const ISyst*);
+#endif
 
   //----------------------------------------------------------------------
   void SystShifts::SaveTo(TDirectory* dir, const std::string& name) const
@@ -310,6 +324,7 @@ namespace ana
     return std::make_unique<GaussianPriorSystShifts>(*this);
   }
 
+#ifdef CAFANA_USE_STAN
   //----------------------------------------------------------------------
   stan::math::var GaussianPriorSystShifts::LogPrior() const
   {
@@ -325,4 +340,6 @@ namespace ana
   {
     return exp(LogPrior());
   }
+#endif
+
 } // namespace ana

--- a/CAFAna/Core/SystShifts.cxx
+++ b/CAFAna/Core/SystShifts.cxx
@@ -4,7 +4,10 @@
 
 #include "cafanacore/Registry.h"
 
+#ifdef CAFANA_USE_STAN
 #include "CAFAna/Core/Stan.h"
+#endif
+
 #include "CAFAna/Core/StanUtils.h"
 
 #include <cassert>

--- a/CAFAna/Core/SystShifts.h
+++ b/CAFAna/Core/SystShifts.h
@@ -19,20 +19,10 @@ namespace ana
   {
   public:
     SystShifts();
-//    SystShifts(const ISyst<caf::SRInteractionProxy>* syst, double shift);
-//    SystShifts(const ISyst<caf::SRTrueInteractionProxy>* syst, double shift);
   SystShifts(const ISyst* syst, double shift);
-//    SystShifts(const ISyst<caf::SRInteractionProxy>*syst, stan::math::var shift);
-//    SystShifts(const ISyst<caf::SRTrueInteractionProxy>*, stan::math::var shift);
     SystShifts(const ISyst* syst, stan::math::var shift);
-//    SystShifts(const std::map<const ISyst<caf::SRInteractionProxy>*, double>& shifts);
-//    SystShifts(const std::map<const ISyst<caf::SRTrueInteractionProxy>*, double>& shifts);
     SystShifts(const std::map<const ISyst*, double>& shifts);
-//    SystShifts(const std::unordered_map<const ISyst<caf::SRInteractionProxy>*, double>& shifts);
-//    SystShifts(const std::unordered_map<const ISyst<caf::SRTrueInteractionProxy>*, double>& shifts);
     SystShifts(const std::unordered_map<const ISyst*, double>& shifts);
-//    SystShifts(const std::map<const ISyst<caf::SRInteractionProxy>*, stan::math::var>& shifts);
-//    SystShifts(const std::map<const ISyst<caf::SRTrueInteractionProxy>*, stan::math::var>& shifts);
     SystShifts(const std::map<const ISyst*, stan::math::var>& shifts);
     //virtual ~SystShifts() = default;
 
@@ -45,10 +35,6 @@ namespace ana
 
     /// shift: 0 = nominal; +-1 = 1sigma shifts etc. Arbitrary shifts allowed
     /// set force=true to insert a syst even if the shift is 0
-    //void SetShift(const ISyst<caf::SRInteractionProxy>* syst, double shift, bool force=false);
-    //void SetShift(const ISyst<caf::SRTrueInteractionProxy>* syst, double shift, bool force=false);
-    //void SetShift(const ISyst<caf::SRInteractionProxy>* syst, stan::math::var shift);
-    //void SetShift(const ISyst<caf::SRTrueInteractionProxy>* syst, stan::math::var shift);
     void SetShift(const ISyst* syst, double shift, bool force=false);
     void SetShift(const ISyst* syst, stan::math::var shift);
     

--- a/CAFAna/Core/SystShifts.h
+++ b/CAFAna/Core/SystShifts.h
@@ -87,8 +87,8 @@ namespace ana
     /// override this
     virtual stan::math::var LogPrior() const;
 #else
-    constexpr bool HasStan(const ISyst* s) { return false; }
-    constexpr bool HasAnyStan() {return false; }
+    constexpr bool HasStan(const ISyst* s) const { return false; }
+    constexpr bool HasAnyStan() const {return false; }
 #endif
 
     /// SystShifts with the same set of systs should have the same ID

--- a/CAFAna/Experiment/CovarianceExperiment.cxx
+++ b/CAFAna/Experiment/CovarianceExperiment.cxx
@@ -119,12 +119,14 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+#ifdef CAFANA_USE_STAN
   stan::math::var CovarianceExperiment::LogLikelihood(osc::IOscCalcAdjustableStan *osc,
                                                       const SystShifts &syst) const
   {
     std::cout << "CovarianceExperiment doesn't yet support OscCalcStan" << std::endl;
     abort();
   }
+#endif
 
   //----------------------------------------------------------------------
   void CovarianceExperiment::SetMaskHist(int idx, double xmin, double xmax, double ymin, double ymax)

--- a/CAFAna/Experiment/CovarianceExperiment.h
+++ b/CAFAna/Experiment/CovarianceExperiment.h
@@ -61,8 +61,10 @@ namespace ana
     virtual double ChiSq(osc::IOscCalcAdjustable* osc,
                          const SystShifts& syst = kNoShift) const override;
 
+#ifdef CAFANA_USE_STAN
     stan::math::var LogLikelihood(osc::_IOscCalcAdjustable<stan::math::var> *osc,
                                   const SystShifts &syst = kNoShift) const override;
+#endif
 
     // Didn't make provisions for copying fMC
     CovarianceExperiment(const CovarianceExperiment&) = delete;

--- a/CAFAna/Experiment/ICovarianceMatrix.h
+++ b/CAFAna/Experiment/ICovarianceMatrix.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Eigen/Dense>
+#include <cassert>
 
 namespace ana
 {

--- a/CAFAna/Experiment/IExperiment.h
+++ b/CAFAna/Experiment/IExperiment.h
@@ -1,7 +1,11 @@
 #pragma once
 
 #include "CAFAna/Core/OscCalcFwdDeclare.h"
+
+#ifdef CAFANA_USE_STAN
 #include "CAFAna/Core/StanTypedefs.h"
+#endif
+
 #include "CAFAna/Core/SystShifts.h"
 
 class TDirectory;
@@ -26,12 +30,14 @@ namespace ana
         return 0;
       };
 
+#ifdef CAFANA_USE_STAN
       virtual stan::math::var LogLikelihood(osc::IOscCalcAdjustableStan *osc,
                                             const SystShifts &syst = kNoShift) const
       {
         assert(false && "unimplemented");
         return 0;
       };
+#endif
 
       virtual void SaveTo(TDirectory *dir, const std::string &name) const;
   };

--- a/CAFAna/Experiment/IExperiment.h
+++ b/CAFAna/Experiment/IExperiment.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cassert>
+
 #include "CAFAna/Core/OscCalcFwdDeclare.h"
 
 #ifdef CAFANA_USE_STAN

--- a/CAFAna/Experiment/MultiExperiment.cxx
+++ b/CAFAna/Experiment/MultiExperiment.cxx
@@ -41,7 +41,7 @@ namespace ana
 #ifdef CAFANA_USE_STAN
             localShifts.SetShift(sec, syst.GetShift<stan::math::var>(prim));
 #else
-            NoStanError();
+            util::NoStanError();
 #endif
           }
           else{

--- a/CAFAna/Experiment/MultiExperiment.cxx
+++ b/CAFAna/Experiment/MultiExperiment.cxx
@@ -4,7 +4,11 @@
 
 #include "CAFAna/Core/LoadFromFile.h"
 #include "CAFAna/Core/LoadFromRegistry.h"
+
+#ifdef CAFANA_USE_STAN
 #include "CAFAna/Core/Stan.h"
+#endif
+#include "CAFAna/Core/StanUtils.h"
 
 #include "OscLib/IOscCalc.h"
 
@@ -34,7 +38,11 @@ namespace ana
         // of prim in the sub-experiment.
         if(sec){
           if(syst.HasStan(prim)){
+#ifdef CAFANA_USE_STAN
             localShifts.SetShift(sec, syst.GetShift<stan::math::var>(prim));
+#else
+            NoStanError();
+#endif
           }
           else{
             localShifts.SetShift(sec, syst.GetShift(prim));
@@ -90,6 +98,7 @@ namespace ana
 
 
   //----------------------------------------------------------------------
+#ifdef CAFANA_USE_STAN
   stan::math::var
   MultiExperiment::LogLikelihood(osc::IOscCalcAdjustableStan* osc, const SystShifts &syst) const
   {
@@ -99,7 +108,7 @@ namespace ana
     }
     return ret;
   }
-
+#endif
   //----------------------------------------------------------------------
   void MultiExperiment::SaveTo(TDirectory* dir, const std::string& name) const
   {

--- a/CAFAna/Experiment/MultiExperiment.h
+++ b/CAFAna/Experiment/MultiExperiment.h
@@ -26,8 +26,10 @@ namespace ana
                          const SystShifts& syst = SystShifts::Nominal()) const override;
 
     /// Sum up log-likelihoods of sub-expts.  N.b.: covariance matrix business not currently supported for Stan.
+#ifdef CAFANA_USE_STAN
     stan::math::var LogLikelihood(osc::IOscCalcAdjustableStan* osc,
                                   const SystShifts& syst) const override;
+#endif
 
     /// \brief For the subexperiment \a idx, set up a mapping between
     /// systematics

--- a/CAFAna/Experiment/SingleSampleExperiment.cxx
+++ b/CAFAna/Experiment/SingleSampleExperiment.cxx
@@ -2,7 +2,11 @@
 
 #include "CAFAna/Core/LoadFromFile.h"
 #include "CAFAna/Core/LoadFromRegistry.h"
-#include "CAFAna/Core/Stan.h"
+
+#ifdef CAFANA_USE_STAN
+#incincludelude "CAFAna/Core/Stan.h"
+#endif
+
 #include "CAFAna/Core/StanUtils.h"
 #include "CAFAna/Core/Utilities.h"
 
@@ -57,6 +61,7 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+#ifdef CAFANA_USE_STAN
   stan::math::var SingleSampleExperiment::LogLikelihood(osc::IOscCalcAdjustableStan *osc,
                                                         const SystShifts &syst) const
   {
@@ -76,7 +81,7 @@ namespace ana
       return ana::LogLikelihood(pred.GetEigen(fData.POT()), data) / -2.;
     }
   }
-
+#endif
 
   //----------------------------------------------------------------------
   void SingleSampleExperiment::SaveTo(TDirectory* dir, const std::string& name) const

--- a/CAFAna/Experiment/SingleSampleExperiment.h
+++ b/CAFAna/Experiment/SingleSampleExperiment.h
@@ -19,8 +19,10 @@ namespace ana
     virtual double ChiSq(osc::IOscCalcAdjustable* osc,
                          const SystShifts& syst = kNoShift) const override;
 
+#ifdef CAFANA_USE_STAN
     stan::math::var LogLikelihood(osc::_IOscCalcAdjustable<stan::math::var> *osc,
                                   const SystShifts &syst = kNoShift) const override;
+#endif
 
     virtual void SaveTo(TDirectory* dir, const std::string& name) const override;
     static std::unique_ptr<SingleSampleExperiment> LoadFrom(TDirectory* dir, const std::string& name);

--- a/CAFAna/Fit/Bayesian1DMarginal.cxx
+++ b/CAFAna/Fit/Bayesian1DMarginal.cxx
@@ -2,7 +2,6 @@
 
 #include "CAFAna/Core/Binning.h"
 #include "CAFAna/Core/IFitVar.h"
-#include "CAFAna/Core/Stan.h"
 #include "CAFAna/Core/Utilities.h"
 #include "CAFAna/Fit/MCMCSamples.h"
 

--- a/CAFAna/Fit/CMakeLists.txt
+++ b/CAFAna/Fit/CMakeLists.txt
@@ -10,10 +10,15 @@ set(Fit_implementation_files
   MCMCSample.cxx
   MCMCSamples.cxx
   MinuitFitter.cxx
-  Priors.cxx
   RefineSeeds.cxx
   SeedList.cxx
-  StanFitter.cxx)
+)
+if(CAFANA_USE_STAN)
+  set(Fit_implementation_files ${Fit_implementation_files}
+      Priors.cxx
+      StanFitter.cxx
+  )
+endif()
 
 set(Fit_header_files
   Bayesian1DMarginal.h
@@ -27,11 +32,16 @@ set(Fit_header_files
   MCMCSample.h
   MCMCSamples.h
   MinuitFitter.h
-  Priors.h
   RefineSeeds.h
   SeedList.h
   StanConfig.h
-  StanFitter.h)
+)
+if(CAFANA_USE_STAN)
+  set(Fit_header_files ${Fit_header_files}
+    StanFitter.h
+    Priors.h
+  )
+endif()
 
 add_library(CAFAnaFit SHARED ${Fit_implementation_files})
 target_link_libraries(CAFAnaFit CAFAnaCore OscLib::All)

--- a/CAFAna/Fit/MCMCSamples.h
+++ b/CAFAna/Fit/MCMCSamples.h
@@ -6,8 +6,6 @@
 #include "TTree.h"
 
 #include "CAFAna/Core/IFitVar.h"
-#include "CAFAna/Core/ISyst.h"
-#include "CAFAna/Core/StanTypedefs.h"
 #include "CAFAna/Fit/BayesianMarginal.h"   // for MarginalMode enum
 #include "CAFAna/Fit/MCMCSample.h"
 #include "CAFAna/Fit/StanConfig.h"
@@ -17,6 +15,7 @@ namespace ana
   // forward declaration
   class Bayesian1DMarginal;
   class BayesianSurface;
+  class ISyst;
 
   /// Storage for a list of MCMC samples.
   ///

--- a/CAFAna/Prediction/IPrediction.cxx
+++ b/CAFAna/Prediction/IPrediction.cxx
@@ -38,12 +38,15 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+#ifdef CAFANA_USE_STAN
   // placeholder method that should be overridden by Stan-aware concrete Prediction classes
   Spectrum IPrediction::Predict(osc::IOscCalcStan *calc) const
   {
     std::cout << "This Prediction hasn't implemented a Stan-aware Predict()!" << std::endl;
     abort();
   }
+#endif
+
   //----------------------------------------------------------------------
   Spectrum IPrediction::PredictSyst(osc::IOscCalc* calc,
                                     const SystShifts& syst) const
@@ -57,6 +60,23 @@ namespace ana
     return Predict(calc);
   }
 
+  //----------------------------------------------------------------------
+  Spectrum IPrediction::PredictComponentSyst(osc::IOscCalc* calc,
+                                             const SystShifts& syst,
+                                             Flavors::Flavors_t flav,
+                                             Current::Current_t curr,
+                                             Sign::Sign_t sign) const
+  {
+    if(!syst.IsNominal()){
+      std::cout << "This Prediction doesn't support PredictSyst(). Did you just mean Predict()?" << std::endl;
+      abort();
+    }
+
+    // Default implementation: no treatment of systematics
+    return PredictComponent(calc, flav, curr, sign);
+  }
+
+#ifdef CAFANA_USE_STAN
   //----------------------------------------------------------------------
   Spectrum IPrediction::PredictSyst(osc::IOscCalcStan* calc,
                                     const SystShifts& syst) const
@@ -82,22 +102,6 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
-  Spectrum IPrediction::PredictComponentSyst(osc::IOscCalc* calc,
-                                             const SystShifts& syst,
-                                             Flavors::Flavors_t flav,
-                                             Current::Current_t curr,
-                                             Sign::Sign_t sign) const
-  {
-    if(!syst.IsNominal()){
-      std::cout << "This Prediction doesn't support PredictSyst(). Did you just mean Predict()?" << std::endl;
-      abort();
-    }
-
-    // Default implementation: no treatment of systematics
-    return PredictComponent(calc, flav, curr, sign);
-  }
-
-  //----------------------------------------------------------------------
   Spectrum IPrediction::PredictComponentSyst(osc::IOscCalcStan* calc,
                                              const SystShifts& syst,
                                              Flavors::Flavors_t flav,
@@ -111,6 +115,7 @@ namespace ana
     // Default implementation: no treatment of systematics
     return PredictComponent(calc, flav, curr, sign);
   }
+#endif
 
   //----------------------------------------------------------------------
   OscillatableSpectrum IPrediction::ComponentCC(int from, int to) const

--- a/CAFAna/Prediction/IPrediction.h
+++ b/CAFAna/Prediction/IPrediction.h
@@ -100,30 +100,30 @@ namespace ana {
     virtual Spectrum PredictUnoscillated() const;
     
     virtual Spectrum Predict(osc::IOscCalc* calc) const = 0;
-    virtual Spectrum Predict(osc::IOscCalcStan* calc) const;
-
     virtual Spectrum PredictSyst(osc::IOscCalc* calc, const SystShifts& syst) const;
-    virtual Spectrum PredictSyst(osc::IOscCalcStan* calc, const SystShifts& syst) const;
-
     virtual Spectrum PredictComponent(osc::IOscCalc* calc,
                                       Flavors::Flavors_t flav,
                                       Current::Current_t curr,
                                       Sign::Sign_t sign) const = 0;
-    virtual Spectrum PredictComponent(osc::IOscCalcStan* calc,
-                                      Flavors::Flavors_t flav,
-                                      Current::Current_t curr,
-                                      Sign::Sign_t sign) const;
-    
     virtual Spectrum PredictComponentSyst(osc::IOscCalc* calc,
                                           const SystShifts& syst,
                                           Flavors::Flavors_t flav,
                                           Current::Current_t curr,
                                           Sign::Sign_t sign) const;
+
+#ifdef CAFANA_USE_STAN
+    virtual Spectrum Predict(osc::IOscCalcStan* calc) const;
+    virtual Spectrum PredictSyst(osc::IOscCalcStan* calc, const SystShifts& syst) const;
+    virtual Spectrum PredictComponent(osc::IOscCalcStan* calc,
+                                    Flavors::Flavors_t flav,
+                                    Current::Current_t curr,
+                                    Sign::Sign_t sign) const;
     virtual Spectrum PredictComponentSyst(osc::IOscCalcStan* calc,
-                                          const SystShifts& syst,
-                                          Flavors::Flavors_t flav,
-                                          Current::Current_t curr,
-                                          Sign::Sign_t sign) const;
+                                        const SystShifts& syst,
+                                        Flavors::Flavors_t flav,
+                                        Current::Current_t curr,
+                                        Sign::Sign_t sign) const;
+#endif
 
     virtual OscillatableSpectrum ComponentCC(int from, int to) const;
     virtual Spectrum ComponentNCTotal() const;

--- a/CAFAna/Prediction/PredictionExtrap.cxx
+++ b/CAFAna/Prediction/PredictionExtrap.cxx
@@ -4,7 +4,10 @@
 
 #include "CAFAna/Extrap/IExtrap.h"
 #include "CAFAna/Core/LoadFromFile.h"
+
+#ifdef CAFANA_USE_STAN
 #include "CAFAna/Core/Stan.h"
+#endif
 
 #include "TDirectory.h"
 #include "TObjString.h"
@@ -34,6 +37,7 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+#ifdef CAFANA_USE_STAN
   Spectrum PredictionExtrap::Predict(osc::IOscCalcStan* calc) const
   {
     return PredictComponent(calc,
@@ -41,6 +45,7 @@ namespace ana
                             Current::kBoth,
                             Sign::kBoth);
   }
+#endif
 
   //----------------------------------------------------------------------
   // the actual implementation
@@ -95,6 +100,7 @@ namespace ana
 
   //----------------------------------------------------------------------
   // just call the templated guy
+#ifdef CAFANA_USE_STAN
   Spectrum PredictionExtrap::PredictComponent(osc::IOscCalcStan* calc,
                                               Flavors::Flavors_t flav,
                                               Current::Current_t curr,
@@ -102,6 +108,7 @@ namespace ana
   {
     return _PredictComponent(calc, flav, curr, sign);
   }
+#endif
 
   //----------------------------------------------------------------------
   OscillatableSpectrum PredictionExtrap::ComponentCC(int from, int to) const

--- a/CAFAna/Prediction/PredictionExtrap.h
+++ b/CAFAna/Prediction/PredictionExtrap.h
@@ -21,16 +21,19 @@ namespace ana
     using IPrediction::PredictSyst;
 
     Spectrum Predict(osc::IOscCalc* calc) const override;
-    Spectrum Predict(osc::IOscCalcStan* calc) const override;
 
     Spectrum PredictComponent(osc::IOscCalc* calc,
                               Flavors::Flavors_t flav,
                               Current::Current_t curr,
                               Sign::Sign_t sign) const override;
+
+#ifdef CAFANA_USE_STAN
+    Spectrum Predict(osc::IOscCalcStan* calc) const override;
     Spectrum PredictComponent(osc::IOscCalcStan* calc,
                               Flavors::Flavors_t flav,
                               Current::Current_t curr,
                               Sign::Sign_t sign) const override;
+#endif
 
     OscillatableSpectrum ComponentCC(int from, int to) const override;
     // NC components:

--- a/CAFAna/Prediction/PredictionInterp.cxx
+++ b/CAFAna/Prediction/PredictionInterp.cxx
@@ -423,8 +423,8 @@ namespace ana
     static_assert(std::is_same_v<T, double>
 #ifdef CAFANA_USE_STAN
     || std::is_same_v<T, stan::math::var>
-#endif,
-                  "PredictionInterp::ShiftBins() can only be called using doubles or stan::math::vars");
+#endif
+                  , "PredictionInterp::ShiftBins() can only be called using doubles or stan::math::vars");
     if(nubar) assert(fSplitBySign);
 
 #ifdef CAFANA_USE_STAN
@@ -541,8 +541,11 @@ namespace ana
                                                Sign::Sign_t sign,
                                                CoeffsType type) const
   {
-    static_assert(std::is_same<T, double>::value || std::is_same<T, stan::math::var>::value,
-                  "PredictionInterp::ShiftedComponent() can only be called using doubles or stan::math::vars");
+    static_assert(std::is_same<T, double>::value
+#ifdef CAFANA_USE_STAN
+    || std::is_same<T, stan::math::var>::value
+#endif
+    , "PredictionInterp::ShiftedComponent() can only be called using doubles or stan::math::vars");
 
     if(fSplitBySign && sign == Sign::kBoth){
       return (ShiftedComponent(calc, hash, shift, flav, curr, Sign::kAntiNu, type)+

--- a/CAFAna/Prediction/PredictionInterp.h
+++ b/CAFAna/Prediction/PredictionInterp.h
@@ -53,33 +53,32 @@ namespace ana
 
 
     Spectrum Predict(osc::IOscCalc* calc) const override;
-    Spectrum Predict(osc::IOscCalcStan* calc) const override;
-
-
     Spectrum PredictSyst(osc::IOscCalc* calc,
                          const SystShifts& shift) const override;
-    Spectrum PredictSyst(osc::IOscCalcStan* calc,
-                         const SystShifts& shift) const override;
-
     Spectrum PredictComponent(osc::IOscCalc* calc,
                               Flavors::Flavors_t flav,
                               Current::Current_t curr,
                               Sign::Sign_t sign) const override;
-    Spectrum PredictComponent(osc::IOscCalcStan* calc,
-                              Flavors::Flavors_t flav,
-                              Current::Current_t curr,
-                              Sign::Sign_t sign) const override;
-
     Spectrum PredictComponentSyst(osc::IOscCalc* calc,
                                   const SystShifts& shift,
                                   Flavors::Flavors_t flav,
                                   Current::Current_t curr,
                                   Sign::Sign_t sign) const override;
+
+#ifdef CAFANA_USE_STAN
+    Spectrum Predict(osc::IOscCalcStan* calc) const override;
+    Spectrum PredictSyst(osc::IOscCalcStan* calc,
+                           const SystShifts& shift) const override;
+    Spectrum PredictComponent(osc::IOscCalcStan* calc,
+                              Flavors::Flavors_t flav,
+                              Current::Current_t curr,
+                              Sign::Sign_t sign) const override;
     Spectrum PredictComponentSyst(osc::IOscCalcStan* calc,
                                   const SystShifts& shift,
                                   Flavors::Flavors_t flav,
                                   Current::Current_t curr,
                                   Sign::Sign_t sign) const override;
+#endif
 
     virtual void SaveTo(TDirectory* dir, const std::string& name) const override;
     static std::unique_ptr<PredictionInterp> LoadFrom(TDirectory* dir, const std::string& name);
@@ -164,6 +163,7 @@ namespace ana
                               Sign::Sign_t sign,
                               CoeffsType type) const;
 
+#ifdef CAFANA_USE_STAN
     Spectrum ShiftedComponent(osc::IOscCalcStan* calc,
                               const TMD5* hash,
                               const SystShifts& shift,
@@ -171,6 +171,7 @@ namespace ana
                               Current::Current_t curr,
                               Sign::Sign_t sign,
                               CoeffsType type) const;
+#endif
 
     template <typename T> T *GetPredNomAs() {
       return dynamic_cast<T *>(fPredNom.get());

--- a/CAFAna/Prediction/PredictionInterpKernel.cxx
+++ b/CAFAna/Prediction/PredictionInterpKernel.cxx
@@ -7,7 +7,9 @@
 //
 // and look at PredictionInterpKernel.s for xmm, ymm or zmm registers
 
+#ifdef CAFANA_USE_STAN
 #include "CAFAna/Core/Stan.h"
+#endif
 
 namespace ana
 {
@@ -24,6 +26,7 @@ namespace ana
       } // end for n
     }
 
+#ifdef CAFANA_USE_STAN
     void ShiftSpectrumKernel(const Coeffs* fits,
                              unsigned int N,
                              const stan::math::var& x,
@@ -38,6 +41,7 @@ namespace ana
       } // end for n
 
     }
+#endif
 
   }
 }

--- a/CAFAna/Prediction/PredictionInterpKernel.h
+++ b/CAFAna/Prediction/PredictionInterpKernel.h
@@ -27,6 +27,6 @@ namespace ana
                              unsigned int N,
                              const stan::math::var& x, const stan::math::var& x2, const stan::math::var& x3,
                              stan::math::var* corr);
-  }
 #endif
+  }
 }

--- a/CAFAna/Prediction/PredictionInterpKernel.h
+++ b/CAFAna/Prediction/PredictionInterpKernel.h
@@ -18,6 +18,7 @@ namespace ana
                              double x, double x2, double x3,
                              double* corr);
 
+#ifdef CAFANA_USE_STAN
     /// Normally I'd make the <double> variant templated,
     /// but this function is so short that it makes more sense
     /// to leave the one with <double> arguments pass-by-value
@@ -27,4 +28,5 @@ namespace ana
                              const stan::math::var& x, const stan::math::var& x2, const stan::math::var& x3,
                              stan::math::var* corr);
   }
+#endif
 }

--- a/CAFAna/Prediction/PredictionNoOsc.h
+++ b/CAFAna/Prediction/PredictionNoOsc.h
@@ -32,15 +32,15 @@ public:
     return fSpectrum;
   }
 
-  virtual Spectrum Predict(osc::IOscCalcStan* /*calc*/) const override {
-    return fSpectrum;
-  }
-
   virtual Spectrum PredictComponent(osc::IOscCalc *calc,
                                     Flavors::Flavors_t flav,
                                     Current::Current_t curr,
                                     Sign::Sign_t sign) const override;
 
+#ifdef CAFANA_USE_STAN
+  virtual Spectrum Predict(osc::IOscCalcStan* /*calc*/) const override {
+    return fSpectrum;
+  }
   virtual Spectrum PredictComponent(osc::IOscCalcStan* /*calc*/,
                                     Flavors::Flavors_t flav,
                                     Current::Current_t curr,
@@ -48,6 +48,7 @@ public:
   {
     return PredictComponent((osc::IOscCalc*)0, flav, curr, sign);
   }
+#endif
 
 protected:
   PredictionNoOsc(const Spectrum &s, const Spectrum &sNCTot, const Spectrum &sNC, 

--- a/CAFAna/Vars/FitVars.cxx
+++ b/CAFAna/Vars/FitVars.cxx
@@ -1,8 +1,11 @@
 #include "CAFAna/Vars/FitVars.h"
 
 #include "CAFAna/Core/MathUtil.h"
+
+#ifdef CAFANA_USE_STAN
 #include "CAFAna/Core/Stan.h"
 #include "CAFAna/Core/StanVar.h"
+#endif
 
 #include "OscLib/IOscCalc.h"
 

--- a/CAFAna/Vars/FitVars.cxx
+++ b/CAFAna/Vars/FitVars.cxx
@@ -79,20 +79,24 @@ namespace ana
   {
     return dcP_GetVal_Helper(osc);
   }
+#ifdef CAFANA_USE_STAN
   stan::math::var FitDeltaInPiUnits::GetValue(const osc::IOscCalcAdjustableStan* osc) const
   {
     return dcP_GetVal_Helper(osc);
   }
+#endif
 
   //----------------------------------------------------------------------
   void FitDeltaInPiUnits::SetValue(osc::IOscCalcAdjustable* osc, double val) const
   {
     osc->SetdCP(M_PI*val);
   }
+#ifdef CAFANA_USE_STAN
   void FitDeltaInPiUnits::SetValue(osc::IOscCalcAdjustableStan* osc, stan::math::var val) const
   {
     osc->SetdCP(M_PI*val);
   }
+#endif
 
   //----------------------------------------------------------------------
   double FitTheta23::GetValue(const osc::IOscCalcAdjustable* osc) const
@@ -113,12 +117,13 @@ namespace ana
   {
     return util::sqr(sin(osc->GetTh23()));
   }
-
+#ifdef CAFANA_USE_STAN
   //----------------------------------------------------------------------
   stan::math::var FitSinSqTheta23::GetValue(const osc::IOscCalcAdjustableStan *osc) const
   {
     return util::sqr(sin(osc->GetTh23()));
   }
+#endif
 
   //----------------------------------------------------------------------
   void FitSinSqTheta23::SetValue(osc::IOscCalcAdjustable* osc, double val) const
@@ -128,10 +133,12 @@ namespace ana
 
 
   //----------------------------------------------------------------------
+#ifdef CAFANA_USE_STAN
   void FitSinSqTheta23::SetValue(osc::IOscCalcAdjustableStan *osc, stan::math::var val) const
   {
     osc->SetTh23(asin(sqrt(this->Clamp(val))));
   }
+#endif
 
   //----------------------------------------------------------------------
   double FitSinSqTheta23Symmetry::
@@ -199,6 +206,7 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+#ifdef CAFANA_USE_STAN
   stan::math::var FitDmSq32Scaled::GetValue(const osc::IOscCalcAdjustableStan *osc) const
   {
     return osc->GetDmsq32()*1000.0;;
@@ -209,7 +217,7 @@ namespace ana
   {
     osc->SetDmsq32(this->Clamp(val)/1000.0);
   }
-
+#endif
 
   //----------------------------------------------------------------------
   void FitDmSq32Scaled::SetValue(osc::IOscCalcAdjustable* osc, double val) const

--- a/CAFAna/Vars/FitVars.h
+++ b/CAFAna/Vars/FitVars.h
@@ -4,7 +4,10 @@
 
 #include "CAFAna/Core/IFitVar.h"
 #include "CAFAna/Core/StanTypedefs.h"
+
+#ifdef CAFANA_USE_STAN
 #include "CAFAna/Core/StanVar.h"
+#endif
 
 namespace ana
 {
@@ -45,10 +48,12 @@ namespace ana
     public:
       FitDeltaInPiUnits() : StanFitSupport<IFitVar>("delta(pi)", "#delta / #pi") {};
 
-      stan::math::var GetValue(const osc::IOscCalcAdjustableStan* osc) const override;
       double GetValue(const osc::IOscCalcAdjustable* osc) const override;
       void SetValue(osc::IOscCalcAdjustable* osc, double val) const override;
+#ifdef CAFANA_USE_STAN
+      stan::math::var GetValue(const osc::IOscCalcAdjustableStan* osc) const override;
       void SetValue(osc::IOscCalcAdjustableStan* osc, stan::math::var val) const override;
+#endif
  };
 
   /// \f$ \delta_{CP}/\pi \f$
@@ -78,9 +83,11 @@ namespace ana
     {}
 
     double GetValue(const osc::IOscCalcAdjustable* osc) const override;
-    stan::math::var GetValue(const osc::IOscCalcAdjustableStan* osc) const override;
     void SetValue(osc::IOscCalcAdjustable* osc, double val) const override;
+#ifdef CAFANA_USE_STAN
+    stan::math::var GetValue(const osc::IOscCalcAdjustableStan* osc) const override;
     void SetValue(osc::IOscCalcAdjustableStan* osc, stan::math::var val) const override;
+#endif
 
     double LowLimit() const override { return 0; }
     double HighLimit() const override { return 1; }
@@ -196,11 +203,12 @@ namespace ana
                                              "#Deltam^{2}_{32} (10^{-3} eV^{2})")
       {}
     double GetValue(const osc::IOscCalcAdjustable* osc) const override;
-    stan::math::var GetValue(const osc::IOscCalcAdjustableStan* osc) const override;
-
     void SetValue(osc::IOscCalcAdjustable* osc, double val) const override;
-    void SetValue(osc::IOscCalcAdjustableStan* osc, stan::math::var val) const override;
 
+#ifdef CAFANA_USE_STAN
+    stan::math::var GetValue(const osc::IOscCalcAdjustableStan* osc) const override;
+    void SetValue(osc::IOscCalcAdjustableStan* osc, stan::math::var val) const override;
+#endif
 
     // "1eV^2 splitting should be enough for anyone"
     // OscCalcPMNS freaks out at large splittings

--- a/CAFAna/cmake/FindExternals.cmake
+++ b/CAFAna/cmake/FindExternals.cmake
@@ -2,7 +2,13 @@ find_package(perftools)
 
 find_package(GSL REQUIRED)
 find_package(Boost REQUIRED COMPONENTS filesystem)
+
+if (CAFANACORE_USE_STAN)
 find_package(Stan REQUIRED)
+else()
+  # Stan would normally drag Eigen in, but if we're not using Stan, we can't count on that
+  find_package(Eigen3Local REQUIRED)
+endif()
 
 find_package(OscLib REQUIRED)
 find_package(CAFAnaCore REQUIRED)

--- a/CAFAna/cmake/FindSundials.cmake
+++ b/CAFAna/cmake/FindSundials.cmake
@@ -14,7 +14,7 @@ find_path(Sundials_INC_DIR
   NO_DEFAULT_PATH)
 
 find_path(Sundials_LIB_DIR
-  NAMES libsundials_cvodes.a
+  NAMES libsundials_cvodes.so
   PATHS ${SUNDIALS_LIB}
   NO_DEFAULT_PATH)
 

--- a/CAFAna/cmake/ups_env_setup.sh
+++ b/CAFAna/cmake/ups_env_setup.sh
@@ -23,7 +23,7 @@ setup osclib v00.27 -q e26:n319:prof:stan || exit 1
 #setup cafanacore v02.03 -q e26:n319:prof || exit 1
 
 export PRODUCTS="/exp/dune/app/users/jwolcott/ups"
-setup cafanacore testing -q e26:prof || exit 1
+setup cafanacore testing -q e26:prof:stanfree || exit 1
 
 
 setup duneanaobj v03_07_00 -q e26:prof || exit 1

--- a/CAFAna/cmake/ups_env_setup.sh
+++ b/CAFAna/cmake/ups_env_setup.sh
@@ -22,7 +22,7 @@ setup osclib v00.27 -q e26:n319:prof:stanfree || exit 1
 
 #setup cafanacore v02.03 -q e26:n319:prof || exit 1
 
-export PRODUCTS="/exp/dune/app/users/jwolcott/ups"
+export PRODUCTS="/exp/dune/app/users/jwolcott/ups:$PRODUCTS"
 setup cafanacore testing -q e26:prof:stanfree || exit 1
 
 

--- a/CAFAna/cmake/ups_env_setup.sh
+++ b/CAFAna/cmake/ups_env_setup.sh
@@ -15,10 +15,10 @@ setup boost v1_82_0 -q e26:prof || exit 1
 setup fhiclcpp v4_18_04 -q e26:prof || exit 1 # for prism
 
 setup eigen v23_08_01_66e8f || exit 1
-setup sundials v6_5_0 || exit 1
-setup stan v2_35_0a || exit 1
+#setup sundials v6_5_0 || exit 1
+#setup stan v2_35_0a || exit 1
 
-setup osclib v00.27 -q e26:n319:prof:stan || exit 1
+setup osclib v00.27 -q e26:n319:prof:stanfree || exit 1
 
 #setup cafanacore v02.03 -q e26:n319:prof || exit 1
 

--- a/CAFAna/cmake/ups_env_setup.sh
+++ b/CAFAna/cmake/ups_env_setup.sh
@@ -2,27 +2,31 @@
 
 source /cvmfs/dune.opensciencegrid.org/products/dune/setup_dune.sh
 
-# temporary until we get updated builds of all the dependent products
-export PRODUCTS="/exp/dune/app/users/jwolcott/ups:$PRODUCTS"
-
 if [ -z "${UPS_SHELL}" ]; then
   echo "[ERROR]: Is UPS set up?"
   exit 1
 fi
 
-setup root v6_28_12  -q e20:p3915:prof || exit 1
-setup boost v1_75_0 -q e20:prof || exit 1
 setup cmake v3_22_2 || exit 1
-setup jobsub_client || exit 1
-setup fhiclcpp v4_15_03 -q e20:prof || exit 1 # for prism
 
-setup eigen v3_4_0 || exit 1
-setup stan v2_26_1 -q e20:prof || exit 1
+setup root v6_28_12  -q e26:p3915:prof || exit 1
+setup boost v1_82_0 -q e26:prof || exit 1
 
-# these will need to be updated as soon as we have official builds for them
-setup osclib testing -q e20:prof:stanfree || exit 1
-setup cafanacore testing -q e20:prof || exit 1
-setup duneanaobj vtesting -q e20:debug || exit 1
+setup fhiclcpp v4_18_04 -q e26:prof || exit 1 # for prism
+
+setup eigen v23_08_01_66e8f || exit 1
+setup sundials v6_5_0 || exit 1
+setup stan v2_35_0a || exit 1
+
+setup osclib v00.27 -q e26:n319:prof:stan || exit 1
+
+#setup cafanacore v02.03 -q e26:n319:prof || exit 1
+
+export PRODUCTS="/exp/dune/app/users/jwolcott/ups"
+setup cafanacore testing -q e26:prof || exit 1
+
+
+setup duneanaobj v03_07_00 -q e26:prof || exit 1
 
 
 


### PR DESCRIPTION
The current `main` won't build because of changes in the dependencies coming in with the `e26` larsoft software stack---some of the versions of the dependencies are mutually incompatible (particularly Sundials, TBB, and Stan).  It's possible to carve around them if we simply disable Stan.

This PR introduces a compile-time option to disable Stan, which can be used to temporarily get things building.  It depends on a similar option for CAFAnaCore, which is under consideration there ([PR #24](https://github.com/cafana/CAFAnaCore/pull/24)), but a temporary build is now available for machines having access to the Fermilab CEPH file system (`/exp/dune/app/users/jwolcott`), which this PR uses.  This will be overridden with an official version (in another PR) once available. 

With this PR in place, the `main` branch should build using `standalone_configure_and_build.sh`.