### PR TITLE
Minor `include` to Fix Build

### DIFF
--- a/CAFAna/Experiment/ICovarianceMatrix.h
+++ b/CAFAna/Experiment/ICovarianceMatrix.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Eigen/Dense>
+#include <cassert>
 
 namespace ana
 {


### PR DESCRIPTION
I tried to build the base branch here inside the SL7 container using

```
./standalone_configure_and_build.sh -r -u -I `pwd`
```

but got complaints

```
/exp/dune/app/users/abooth/Postdoc/LBL/ExtrapAna/lblpwgtools/CAFAna/Experiment/ICovarianceMatrix.cxx:10:5: error: ‘assert’ was not declared in this scope
   10 |     assert(a.size() == fMaskA.size());
      |     ^~~~~~
```

probably from `cassert` include being removed from `Binning.cxx` in #59. I figured it was better to put the `cassert` include in `ICovarianceMatrix.h` rather than put it back in `Binning.cxx` but couldn't find a way to do this as a "suggestion" within the PR so opening this small PR instead.

Successful build with this minor fix.